### PR TITLE
chore: pin pnpm via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/scotthavird/claude-code-template.git"
-  }
-} 
+  },
+  "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39"
+}


### PR DESCRIPTION
Adds `packageManager: pnpm@10.10.0` (with integrity hash) to `package.json` so Corepack auto-installs the exact pnpm version across contributors and CI.

**What this prevents:** lockfile churn from mismatched pnpm installs on different machines.

**Breaking:** none. Contributors who don't use Corepack continue to work as before.

## Test plan
- [ ] `jq . package.json` — validates.
- [ ] `corepack enable && pnpm --version` — should print `10.10.0` after cloning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)