### PR TITLE
fix(ci): skip Claude workflows cleanly when ANTHROPIC_API_KEY is unset

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,8 +4,31 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# Two-job pattern: a tiny gate job exposes whether ANTHROPIC_API_KEY is set
+# (since `if: ${{ secrets.X != '' }}` is not allowed at job level), and the
+# review job is gated on that. When the secret is missing, the review job
+# is skipped — not failed — so a fresh fork of this template doesn't get
+# red CI before the maintainer adds the key.
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      has_key: ${{ steps.check.outputs.has_key }}
+    steps:
+      - id: check
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ANTHROPIC_API_KEY is not set in repo Actions secrets — skipping Claude review. Add the secret in Settings → Secrets and variables → Actions to enable."
+          fi
+
   review:
+    needs: check-secret
+    if: needs.check-secret.outputs.has_key == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,13 +10,35 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Two-job pattern: a tiny gate job exposes whether ANTHROPIC_API_KEY is set,
+# so the @claude responder is skipped (not failed) when the secret is
+# missing. See claude-review.yml for the same pattern.
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      has_key: ${{ steps.check.outputs.has_key }}
+    steps:
+      - id: check
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ANTHROPIC_API_KEY is not set in repo Actions secrets — skipping @claude responder. Add the secret in Settings → Secrets and variables → Actions to enable."
+          fi
+
   claude:
+    needs: check-secret
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      needs.check-secret.outputs.has_key == 'true' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -10,7 +10,12 @@ issues, and review comments.
 `.github/workflows/claude-review.yml` — runs a review pass on every new
 PR or push to an open PR.
 
-Both require `ANTHROPIC_API_KEY` in the repo's Actions secrets. See the
+Both require `ANTHROPIC_API_KEY` in the repo's Actions secrets. **If the
+secret is not set, both workflows skip cleanly** (a `check-secret` gate
+job emits a workflow notice and the responder/review job is marked
+*skipped*, not failed) — so a fresh fork doesn't get red CI on every PR
+before you've configured the key. Add the secret at *Settings → Secrets
+and variables → Actions* to enable. See the
 [Claude Code GitHub Actions doc](https://code.claude.com/docs/en/github-actions).
 
 ## GitLab CI/CD


### PR DESCRIPTION
## Summary

Hardens both shipped GitHub Actions workflows (`claude.yml` and `claude-review.yml`) so that they skip cleanly when `ANTHROPIC_API_KEY` is not configured, rather than failing with an opaque environment-validation error. Fresh forks of this template now get green/skipped CI on PRs until the maintainer adds the secret — no red checks before any code is even written.

Closes #6

## Changes

### `.github/workflows/claude-review.yml` and `claude.yml`
- Add a `check-secret` gate job that runs first and exposes a boolean output `has_key`. (Job-level `if: ${{ secrets.X != '' }}` isn't allowed by GitHub Actions, hence the gate-job pattern.)
- Gate the existing responder / review job on `needs.check-secret.outputs.has_key == 'true'`.
- Emit a `::notice::` annotation with actionable wording when the secret is missing: where to add it (*Settings → Secrets and variables → Actions*) and what name (`ANTHROPIC_API_KEY`).

### `docs/integrations.md`
- Note the graceful-skip behavior so users understand why a fresh fork shows skipped jobs.

## Architecture

```mermaid
flowchart LR
  PR[pull_request opened/sync] --> CS[check-secret job]
  CS -->|secret set| RV[review job runs]
  CS -->|secret absent| SK[review job skipped]
  CS -.->|::notice::| MAINT[maintainer sees actionable hint]
```

## Code Walkthrough

### Why a separate gate job?

```yaml
jobs:
  check-secret:
    runs-on: ubuntu-latest
    outputs:
      has_key: ${{ steps.check.outputs.has_key }}
    steps:
      - id: check
        env:
          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
        run: |
          if [ -n "$ANTHROPIC_API_KEY" ]; then
            echo "has_key=true" >> "$GITHUB_OUTPUT"
          else
            echo "has_key=false" >> "$GITHUB_OUTPUT"
            echo "::notice::ANTHROPIC_API_KEY is not set..."
          fi
```

GitHub Actions intentionally restricts `secrets.*` evaluation in job-level `if` conditions to prevent secret oracling. The supported pattern is to expose the secret to a step via `env:`, evaluate at runtime, and propagate the result through `outputs`. The cost is one extra short-lived job; the benefit is that downstream jobs are *skipped* (which counts as success at the workflow level), not *failed*.

## Testing

- YAML validation: `python -c "import yaml; yaml.safe_load(open('...'))"` for both files.
- End-to-end test: this PR is itself the first run of the updated workflow against a repo that doesn't (currently) have `ANTHROPIC_API_KEY` set. If `check-secret` succeeds and `review` is *skipped* on this PR, the fix is confirmed.
- Edge case considered: `claude.yml`'s existing `@claude`-mention conditional is preserved — it now ANDs with the secret-present check.

## Agent Review Context

- **change-type**: fix
- **risk-level**: low
- **key-files**: `.github/workflows/claude-review.yml`, `.github/workflows/claude.yml`
- **testing-confidence**: high (YAML valid; the PR run itself is the proof)

## Checklist

- [x] YAML syntactically valid
- [x] Behavior unchanged when secret IS set
- [x] No breaking changes
- [x] Docs updated (`docs/integrations.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
